### PR TITLE
feat: 프로필 들어온 사용자 조회 및 프로필 정보 조회

### DIFF
--- a/backend/carbook/src/main/java/softeer/carbook/domain/follow/repository/FollowRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/follow/repository/FollowRepository.java
@@ -31,6 +31,12 @@ public class FollowRepository {
         return jdbcTemplate.queryForObject("select count(*) from FOLLOW where follower_id = ?", Integer.class, followerId);
     }
 
+    public boolean isFollow(int id, int followingId) {
+        return jdbcTemplate.queryForObject(
+                "select count(*) from FOLLOW where follower_id = ? and following_id = ?",
+                Integer.class, id, followingId) != 0;
+    }
+
     private RowMapper<Integer> followerIdRowMapper(){
         return (rs, rowNum) -> {
             Integer followerId = rs.getInt("follower_id");
@@ -44,5 +50,6 @@ public class FollowRepository {
             return followingId;
         };
     }
+
 
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/follow/repository/FollowRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/follow/repository/FollowRepository.java
@@ -33,7 +33,7 @@ public class FollowRepository {
 
     public boolean isFollow(int id, int followingId) {
         return jdbcTemplate.queryForObject(
-                "select count(*) from FOLLOW where follower_id = ? and following_id = ?",
+                "select EXISTS (select * from FOLLOW where follower_id = ? and following_id = ? limit 1) as success",
                 Integer.class, id, followingId) != 0;
     }
 

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/controller/PostController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/controller/PostController.java
@@ -11,6 +11,8 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 import softeer.carbook.domain.post.dto.GuestPostsResponse;
 import softeer.carbook.domain.post.dto.LoginPostsResponse;
 import softeer.carbook.domain.post.dto.PostsSearchResponse;
+import softeer.carbook.domain.post.dto.MyProfileResponse;
+import softeer.carbook.domain.post.dto.OtherProfileResponse;
 import softeer.carbook.domain.post.service.PostService;
 import softeer.carbook.domain.user.model.User;
 import softeer.carbook.domain.user.service.UserService;
@@ -81,12 +83,12 @@ public class PostController {
 
         // 현재 접속한 사용자가 해당 프로필 유저 인가요? >> 내 프로필 페이지
         if(loginUser.getNickname().equals(nickname)){
-            postService.myProfile(loginUser);
-            return new ResponseEntity<>(HttpStatus.OK);
+            MyProfileResponse myProfileResponse = postService.myProfile(loginUser);
+            return new ResponseEntity<>(myProfileResponse, HttpStatus.OK);
         }
         // 현재 접속한 사용자가 다른 사람의 프로필을 들어 갔나요 >> 타인의 프로필 페이지
-        postService.otherProfile(loginUser);
-        return new ResponseEntity<>(HttpStatus.OK);
+        OtherProfileResponse otherProfileResponse = postService.otherProfile(loginUser, nickname);
+        return new ResponseEntity<>(otherProfileResponse, HttpStatus.OK);
     }
 
         // 닉네임 변경 ( 자신 프로필 페이지) > user 로

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/controller/PostController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/controller/PostController.java
@@ -81,12 +81,11 @@ public class PostController {
 
         // 현재 접속한 사용자가 해당 프로필 유저 인가요? >> 내 프로필 페이지
         if(loginUser.getNickname().equals(nickname)){
-
+            postService.myProfile(loginUser);
+            return new ResponseEntity<>(HttpStatus.OK);
         }
-
         // 현재 접속한 사용자가 다른 사람의 프로필을 들어 갔나요 >> 타인의 프로필 페이지
-
-
+        postService.otherProfile(loginUser);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/dto/MyProfileResponse.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/dto/MyProfileResponse.java
@@ -54,27 +54,27 @@ public class MyProfileResponse {
         public MyProfileResponseBuilder() {
         }
 
-        public MyProfileResponseBuilder setNickname(String nickname) {
+        public MyProfileResponseBuilder nickname(String nickname) {
             this.nickname = nickname;
             return this;
         }
 
-        public MyProfileResponseBuilder setEmail(String email) {
+        public MyProfileResponseBuilder email(String email) {
             this.email = email;
             return this;
         }
 
-        public MyProfileResponseBuilder setFollower(int follower) {
+        public MyProfileResponseBuilder follower(int follower) {
             this.follower = follower;
             return this;
         }
 
-        public MyProfileResponseBuilder setFollowing(int following) {
+        public MyProfileResponseBuilder following(int following) {
             this.following = following;
             return this;
         }
 
-        public MyProfileResponseBuilder setImages(List<Image> images) {
+        public MyProfileResponseBuilder images(List<Image> images) {
             this.images = images;
             return this;
         }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/dto/MyProfileResponse.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/dto/MyProfileResponse.java
@@ -1,0 +1,34 @@
+package softeer.carbook.domain.post.dto;
+
+import softeer.carbook.domain.post.model.Image;
+
+import java.util.List;
+
+public class MyProfileResponse {
+    private final boolean isMyProfile = true;
+    private String nickname;
+    private String email;
+    private int follower;
+    private int following;
+    private List<Image> images;
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public void setFollower(int follower) {
+        this.follower = follower;
+    }
+
+    public void setFollowing(int following) {
+        this.following = following;
+    }
+
+    public void setImages(List<Image> images) {
+        this.images = images;
+    }
+}

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/dto/MyProfileResponse.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/dto/MyProfileResponse.java
@@ -16,6 +16,30 @@ public class MyProfileResponse {
         this.nickname = nickname;
     }
 
+    public boolean isMyProfile() {
+        return isMyProfile;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public int getFollower() {
+        return follower;
+    }
+
+    public int getFollowing() {
+        return following;
+    }
+
+    public List<Image> getImages() {
+        return images;
+    }
+
     public void setEmail(String email) {
         this.email = email;
     }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/dto/MyProfileResponse.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/dto/MyProfileResponse.java
@@ -12,8 +12,12 @@ public class MyProfileResponse {
     private int following;
     private List<Image> images;
 
-    public void setNickname(String nickname) {
-        this.nickname = nickname;
+    public MyProfileResponse(MyProfileResponseBuilder myProfileResponseBuilder) {
+        this.nickname = myProfileResponseBuilder.nickname;
+        this.email = myProfileResponseBuilder.email;
+        this.follower = myProfileResponseBuilder.follower;
+        this.following = myProfileResponseBuilder.following;
+        this.images = myProfileResponseBuilder.images;
     }
 
     public boolean isMyProfile() {
@@ -40,19 +44,44 @@ public class MyProfileResponse {
         return images;
     }
 
-    public void setEmail(String email) {
-        this.email = email;
+    public static class MyProfileResponseBuilder{
+        private String nickname;
+        private String email;
+        private int follower;
+        private int following;
+        private List<Image> images;
+
+        public MyProfileResponseBuilder() {
+        }
+
+        public MyProfileResponseBuilder setNickname(String nickname) {
+            this.nickname = nickname;
+            return this;
+        }
+
+        public MyProfileResponseBuilder setEmail(String email) {
+            this.email = email;
+            return this;
+        }
+
+        public MyProfileResponseBuilder setFollower(int follower) {
+            this.follower = follower;
+            return this;
+        }
+
+        public MyProfileResponseBuilder setFollowing(int following) {
+            this.following = following;
+            return this;
+        }
+
+        public MyProfileResponseBuilder setImages(List<Image> images) {
+            this.images = images;
+            return this;
+        }
+
+        public MyProfileResponse build(){
+            return new MyProfileResponse(this);
+        }
     }
 
-    public void setFollower(int follower) {
-        this.follower = follower;
-    }
-
-    public void setFollowing(int following) {
-        this.following = following;
-    }
-
-    public void setImages(List<Image> images) {
-        this.images = images;
-    }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/dto/OtherProfileResponse.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/dto/OtherProfileResponse.java
@@ -13,31 +13,59 @@ public class OtherProfileResponse {
     private int following;
     private List<Image> images;
 
-    public void setNickname(String nickname) {
-        this.nickname = nickname;
+    public OtherProfileResponse(OtherProfileResponseBuilder otherProfileResponseBuilder) {
+        this.nickname = otherProfileResponseBuilder.nickname;
+        this.email = otherProfileResponseBuilder.email;
+        this.isFollow = otherProfileResponseBuilder.isFollow;
+        this.follower = otherProfileResponseBuilder.follower;
+        this.following = otherProfileResponseBuilder.following;
+        this.images = otherProfileResponseBuilder.images;
     }
 
-    public boolean isMyProfile() {
-        return isMyProfile;
-    }
+    public static class OtherProfileResponseBuilder {
+        private String nickname;
+        private String email;
+        private boolean isFollow;
+        private int follower;
+        private int following;
+        private List<Image> images;
 
-    public void setEmail(String email) {
-        this.email = email;
-    }
+        public OtherProfileResponseBuilder() {
+        }
 
-    public void setFollow(boolean follow) {
-        isFollow = follow;
-    }
+        public OtherProfileResponseBuilder setNickname(String nickname) {
+            this.nickname = nickname;
+            return this;
+        }
 
-    public void setFollower(int follower) {
-        this.follower = follower;
-    }
+        public OtherProfileResponseBuilder setEmail(String email) {
+            this.email = email;
+            return this;
+        }
 
-    public void setFollowing(int following) {
-        this.following = following;
-    }
+        public OtherProfileResponseBuilder setFollow(boolean follow) {
+            isFollow = follow;
+            return this;
+        }
 
-    public void setImages(List<Image> images) {
-        this.images = images;
+        public OtherProfileResponseBuilder setFollower(int follower) {
+            this.follower = follower;
+            return this;
+        }
+
+        public OtherProfileResponseBuilder setFollowing(int following) {
+            this.following = following;
+            return this;
+        }
+
+        public OtherProfileResponseBuilder setImages(List<Image> images) {
+            this.images = images;
+            return this;
+        }
+
+        public OtherProfileResponse build(){
+            return new OtherProfileResponse(this);
+        }
+
     }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/dto/OtherProfileResponse.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/dto/OtherProfileResponse.java
@@ -1,0 +1,39 @@
+package softeer.carbook.domain.post.dto;
+
+import softeer.carbook.domain.post.model.Image;
+
+import java.util.List;
+
+public class OtherProfileResponse {
+    private final boolean isMyProfile = false;
+    private String nickname;
+    private String email;
+    private boolean isFollow;
+    private int follower;
+    private int following;
+    private List<Image> images;
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public void setFollow(boolean follow) {
+        isFollow = follow;
+    }
+
+    public void setFollower(int follower) {
+        this.follower = follower;
+    }
+
+    public void setFollowing(int following) {
+        this.following = following;
+    }
+
+    public void setImages(List<Image> images) {
+        this.images = images;
+    }
+}

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/dto/OtherProfileResponse.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/dto/OtherProfileResponse.java
@@ -33,32 +33,32 @@ public class OtherProfileResponse {
         public OtherProfileResponseBuilder() {
         }
 
-        public OtherProfileResponseBuilder setNickname(String nickname) {
+        public OtherProfileResponseBuilder nickname(String nickname) {
             this.nickname = nickname;
             return this;
         }
 
-        public OtherProfileResponseBuilder setEmail(String email) {
+        public OtherProfileResponseBuilder email(String email) {
             this.email = email;
             return this;
         }
 
-        public OtherProfileResponseBuilder setFollow(boolean follow) {
+        public OtherProfileResponseBuilder follow(boolean follow) {
             isFollow = follow;
             return this;
         }
 
-        public OtherProfileResponseBuilder setFollower(int follower) {
+        public OtherProfileResponseBuilder follower(int follower) {
             this.follower = follower;
             return this;
         }
 
-        public OtherProfileResponseBuilder setFollowing(int following) {
+        public OtherProfileResponseBuilder following(int following) {
             this.following = following;
             return this;
         }
 
-        public OtherProfileResponseBuilder setImages(List<Image> images) {
+        public OtherProfileResponseBuilder images(List<Image> images) {
             this.images = images;
             return this;
         }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/dto/OtherProfileResponse.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/dto/OtherProfileResponse.java
@@ -17,6 +17,10 @@ public class OtherProfileResponse {
         this.nickname = nickname;
     }
 
+    public boolean isMyProfile() {
+        return isMyProfile;
+    }
+
     public void setEmail(String email) {
         this.email = email;
     }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
@@ -5,6 +5,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 import softeer.carbook.domain.post.model.Image;
+import softeer.carbook.domain.post.model.Post;
 
 import javax.sql.DataSource;
 import java.util.List;
@@ -36,6 +37,26 @@ public class ImageRepository {
                         "and p.id = img.post_id " +
                 "ORDER BY p.create_date DESC LIMIT ?, ?",
                 imageRowMapper(), followerId, index, size);
+    }
+
+    public List<Image> findImagesByUserId(int id) {
+        List<Image> images = jdbcTemplate.query(
+                "select * from POST INNER JOIN IMAGE " +
+                        "ON POST.id = IMAGE.post_id " +
+                        "WHERE POST.user_id = ? " +
+                        "ORDER BY create_date ",
+                imageRowMapper(), id);
+        return images;
+    }
+
+    public List<Image> findImagesByNickName(String profileUserNickname) {
+        List<Image> images = jdbcTemplate.query(
+                "select * from USER, POST, IMAGE " +
+                        "WHERE USER.id = POST.user_id and POST.id = IMAGE.post_id " +
+                        "and USER.nickname = ?" +
+                        "ORDER BY create_date ",
+                imageRowMapper(), profileUserNickname);
+        return images;
     }
 
     private RowMapper<Image> imageRowMapper(){

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
@@ -44,7 +44,7 @@ public class ImageRepository {
                 "select IMAGE.post_id, IMAGE.image_url from POST INNER JOIN IMAGE " +
                         "ON POST.id = IMAGE.post_id " +
                         "WHERE POST.user_id = ? " +
-                        "ORDER BY create_date ",
+                        "ORDER BY create_date DESC",
                 imageRowMapper(), id);
         return images;
     }
@@ -54,7 +54,7 @@ public class ImageRepository {
                 "select IMAGE.post_id, IMAGE.image_url from USER, POST, IMAGE " +
                         "WHERE USER.id = POST.user_id and POST.id = IMAGE.post_id " +
                         "and USER.nickname = ?" +
-                        "ORDER BY create_date ",
+                        "ORDER BY create_date DESC",
                 imageRowMapper(), profileUserNickname);
         return images;
     }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
@@ -41,7 +41,7 @@ public class ImageRepository {
 
     public List<Image> findImagesByUserId(int id) {
         List<Image> images = jdbcTemplate.query(
-                "select * from POST INNER JOIN IMAGE " +
+                "select IMAGE.post_id, IMAGE.image_url from POST INNER JOIN IMAGE " +
                         "ON POST.id = IMAGE.post_id " +
                         "WHERE POST.user_id = ? " +
                         "ORDER BY create_date ",
@@ -51,7 +51,7 @@ public class ImageRepository {
 
     public List<Image> findImagesByNickName(String profileUserNickname) {
         List<Image> images = jdbcTemplate.query(
-                "select * from USER, POST, IMAGE " +
+                "select IMAGE.post_id, IMAGE.image_url from USER, POST, IMAGE " +
                         "WHERE USER.id = POST.user_id and POST.id = IMAGE.post_id " +
                         "and USER.nickname = ?" +
                         "ORDER BY create_date ",

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/PostRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/PostRepository.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
+import softeer.carbook.domain.post.model.Image;
 import softeer.carbook.domain.post.model.Post;
 
 import javax.sql.DataSource;

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -76,7 +76,7 @@ public class PostService {
         myProfileResponse.setEmail(loginUser.getEmail());
         myProfileResponse.setFollower(123); // todo
         myProfileResponse.setFollowing(1234); // todo
-        myProfileResponse.setImages(null); // todo
+        myProfileResponse.setImages(PostRepository.findPostsByUserId(loginUser.getId())); // todo id로 변경
         return myProfileResponse;
     }
 

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -14,7 +14,6 @@ import softeer.carbook.domain.post.model.Image;
 import softeer.carbook.domain.post.model.Post;
 import softeer.carbook.domain.post.repository.ImageRepository;
 import softeer.carbook.domain.post.repository.PostRepository;
-import softeer.carbook.domain.user.dto.Message;
 import softeer.carbook.domain.user.model.User;
 import softeer.carbook.domain.user.repository.UserRepository;
 
@@ -76,23 +75,23 @@ public class PostService {
 
     public MyProfileResponse myProfile(User loginUser) {
         return new MyProfileResponse.MyProfileResponseBuilder()
-                .setNickname(loginUser.getNickname())
-                .setEmail(loginUser.getEmail())
-                .setFollower(followRepository.getFollowerCount(loginUser.getId()))
-                .setFollowing(followRepository.getFollowingCount(loginUser.getId()))
-                .setImages(imageRepository.findImagesByUserId(loginUser.getId()))
+                .nickname(loginUser.getNickname())
+                .email(loginUser.getEmail())
+                .follower(followRepository.getFollowerCount(loginUser.getId()))
+                .following(followRepository.getFollowingCount(loginUser.getId()))
+                .images(imageRepository.findImagesByUserId(loginUser.getId()))
                 .build();
     }
 
     public OtherProfileResponse otherProfile(User loginUser, String profileUserNickname) {
         int profileUserId = userRepository.findUserIdByNickname(profileUserNickname);
         return new OtherProfileResponse.OtherProfileResponseBuilder()
-                .setNickname(profileUserNickname)
-                .setEmail(userRepository.findEmailByNickname(profileUserNickname))
-                .setFollow(followRepository.isFollow(loginUser.getId(), profileUserId))
-                .setFollower(followRepository.getFollowerCount(profileUserId))
-                .setFollowing(followRepository.getFollowingCount(profileUserId))
-                .setImages(imageRepository.findImagesByNickName(profileUserNickname))
+                .nickname(profileUserNickname)
+                .email(userRepository.findEmailByNickname(profileUserNickname))
+                .follow(followRepository.isFollow(loginUser.getId(), profileUserId))
+                .follower(followRepository.getFollowerCount(profileUserId))
+                .following(followRepository.getFollowingCount(profileUserId))
+                .images(imageRepository.findImagesByNickName(profileUserNickname))
                 .build();
     }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -75,24 +75,24 @@ public class PostService {
     }
 
     public MyProfileResponse myProfile(User loginUser) {
-        MyProfileResponse myProfileResponse = new MyProfileResponse();
-        myProfileResponse.setNickname(loginUser.getNickname());
-        myProfileResponse.setEmail(loginUser.getEmail());
-        myProfileResponse.setFollower(followRepository.getFollowerCount(loginUser.getId()));
-        myProfileResponse.setFollowing(followRepository.getFollowingCount(loginUser.getId()));
-        myProfileResponse.setImages(imageRepository.findImagesByUserId(loginUser.getId()));
-        return myProfileResponse;
+        return new MyProfileResponse.MyProfileResponseBuilder()
+                .setNickname(loginUser.getNickname())
+                .setEmail(loginUser.getEmail())
+                .setFollower(followRepository.getFollowerCount(loginUser.getId()))
+                .setFollowing(followRepository.getFollowingCount(loginUser.getId()))
+                .setImages(imageRepository.findImagesByUserId(loginUser.getId()))
+                .build();
     }
 
     public OtherProfileResponse otherProfile(User loginUser, String profileUserNickname) {
-        OtherProfileResponse otherProfileResponse = new OtherProfileResponse();
         int profileUserId = userRepository.findUserIdByNickname(profileUserNickname);
-        otherProfileResponse.setNickname(profileUserNickname);
-        otherProfileResponse.setEmail(userRepository.findEmailByNickname(profileUserNickname));
-        otherProfileResponse.setFollow(followRepository.isFollow(loginUser.getId(), profileUserId));
-        otherProfileResponse.setFollower(followRepository.getFollowerCount(profileUserId));
-        otherProfileResponse.setFollowing(followRepository.getFollowingCount(profileUserId));
-        otherProfileResponse.setImages(imageRepository.findImagesByNickName(profileUserNickname));
-        return otherProfileResponse;
+        return new OtherProfileResponse.OtherProfileResponseBuilder()
+                .setNickname(profileUserNickname)
+                .setEmail(userRepository.findEmailByNickname(profileUserNickname))
+                .setFollow(followRepository.isFollow(loginUser.getId(), profileUserId))
+                .setFollower(followRepository.getFollowerCount(profileUserId))
+                .setFollowing(followRepository.getFollowingCount(profileUserId))
+                .setImages(imageRepository.findImagesByNickName(profileUserNickname))
+                .build();
     }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -2,6 +2,7 @@ package softeer.carbook.domain.post.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import softeer.carbook.domain.follow.repository.FollowRepository;
 import softeer.carbook.domain.hashtag.model.Hashtag;
 import softeer.carbook.domain.hashtag.repository.HashtagRepository;
 import softeer.carbook.domain.post.dto.GuestPostsResponse;
@@ -26,6 +27,7 @@ public class PostService {
     private final ImageRepository imageRepository;
     private final HashtagRepository hashtagRepository;
     private final UserRepository userRepository;
+    private final FollowRepository followRepository;
     private final int POST_COUNT = 10;
 
     @Autowired
@@ -33,11 +35,13 @@ public class PostService {
             PostRepository postRepository,
             ImageRepository imageRepository,
             HashtagRepository hashtagRepository,
-            UserRepository userRepository) {
+            UserRepository userRepository,
+            FollowRepository followRepository) {
         this.postRepository = postRepository;
         this.imageRepository = imageRepository;
         this.hashtagRepository = hashtagRepository;
         this.userRepository = userRepository;
+        this.followRepository = followRepository;
     }
 
     public GuestPostsResponse getRecentPosts(int index) {
@@ -74,21 +78,21 @@ public class PostService {
         MyProfileResponse myProfileResponse = new MyProfileResponse();
         myProfileResponse.setNickname(loginUser.getNickname());
         myProfileResponse.setEmail(loginUser.getEmail());
-        myProfileResponse.setFollower(123); // todo
-        myProfileResponse.setFollowing(1234); // todo
+        myProfileResponse.setFollower(followRepository.getFollowerCount(loginUser.getId()));
+        myProfileResponse.setFollowing(followRepository.getFollowingCount(loginUser.getId()));
         myProfileResponse.setImages(imageRepository.findImagesByUserId(loginUser.getId()));
         return myProfileResponse;
     }
 
     public OtherProfileResponse otherProfile(User loginUser, String profileUserNickname) {
         OtherProfileResponse otherProfileResponse = new OtherProfileResponse();
+        int profileUserId = userRepository.findUserIdByNickname(profileUserNickname);
         otherProfileResponse.setNickname(profileUserNickname);
         otherProfileResponse.setEmail(userRepository.findEmailByNickname(profileUserNickname));
-        otherProfileResponse.setFollow(true); // todo
-        otherProfileResponse.setFollower(123); // todo
-        otherProfileResponse.setFollowing(1235); // todo
+        otherProfileResponse.setFollow(followRepository.isFollow(loginUser.getId(), profileUserId));
+        otherProfileResponse.setFollower(followRepository.getFollowerCount(profileUserId));
+        otherProfileResponse.setFollowing(followRepository.getFollowingCount(profileUserId));
         otherProfileResponse.setImages(imageRepository.findImagesByNickName(profileUserNickname));
-
         return otherProfileResponse;
     }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -76,7 +76,7 @@ public class PostService {
         myProfileResponse.setEmail(loginUser.getEmail());
         myProfileResponse.setFollower(123); // todo
         myProfileResponse.setFollowing(1234); // todo
-        myProfileResponse.setImages(PostRepository.findPostsByUserId(loginUser.getId())); // todo id로 변경
+        myProfileResponse.setImages(imageRepository.findImagesByUserId(loginUser.getId()));
         return myProfileResponse;
     }
 
@@ -87,7 +87,7 @@ public class PostService {
         otherProfileResponse.setFollow(true); // todo
         otherProfileResponse.setFollower(123); // todo
         otherProfileResponse.setFollowing(1235); // todo
-        otherProfileResponse.setImages(null); // todo
+        otherProfileResponse.setImages(imageRepository.findImagesByNickName(profileUserNickname));
 
         return otherProfileResponse;
     }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -7,12 +7,15 @@ import softeer.carbook.domain.hashtag.repository.HashtagRepository;
 import softeer.carbook.domain.post.dto.GuestPostsResponse;
 import softeer.carbook.domain.post.dto.LoginPostsResponse;
 import softeer.carbook.domain.post.dto.PostsSearchResponse;
+import softeer.carbook.domain.post.dto.MyProfileResponse;
+import softeer.carbook.domain.post.dto.OtherProfileResponse;
 import softeer.carbook.domain.post.model.Image;
 import softeer.carbook.domain.post.model.Post;
 import softeer.carbook.domain.post.repository.ImageRepository;
 import softeer.carbook.domain.post.repository.PostRepository;
 import softeer.carbook.domain.user.dto.Message;
 import softeer.carbook.domain.user.model.User;
+import softeer.carbook.domain.user.repository.UserRepository;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,13 +25,19 @@ public class PostService {
     private final PostRepository postRepository;
     private final ImageRepository imageRepository;
     private final HashtagRepository hashtagRepository;
+    private final UserRepository userRepository;
     private final int POST_COUNT = 10;
 
     @Autowired
-    public PostService(PostRepository postRepository, ImageRepository imageRepository, HashtagRepository hashtagRepository) {
+    public PostService(
+            PostRepository postRepository,
+            ImageRepository imageRepository,
+            HashtagRepository hashtagRepository,
+            UserRepository userRepository) {
         this.postRepository = postRepository;
         this.imageRepository = imageRepository;
         this.hashtagRepository = hashtagRepository;
+        this.userRepository = userRepository;
     }
 
     public GuestPostsResponse getRecentPosts(int index) {
@@ -61,4 +70,25 @@ public class PostService {
         return new PostsSearchResponse(images);
     }
 
+    public MyProfileResponse myProfile(User loginUser) {
+        MyProfileResponse myProfileResponse = new MyProfileResponse();
+        myProfileResponse.setNickname(loginUser.getNickname());
+        myProfileResponse.setEmail(loginUser.getEmail());
+        myProfileResponse.setFollower(123); // todo
+        myProfileResponse.setFollowing(1234); // todo
+        myProfileResponse.setImages(null); // todo
+        return myProfileResponse;
+    }
+
+    public OtherProfileResponse otherProfile(User loginUser, String profileUserNickname) {
+        OtherProfileResponse otherProfileResponse = new OtherProfileResponse();
+        otherProfileResponse.setNickname(profileUserNickname);
+        otherProfileResponse.setEmail(userRepository.findEmailByNickname(profileUserNickname));
+        otherProfileResponse.setFollow(true); // todo
+        otherProfileResponse.setFollower(123); // todo
+        otherProfileResponse.setFollowing(1235); // todo
+        otherProfileResponse.setImages(null); // todo
+
+        return otherProfileResponse;
+    }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/exception/NicknameNotExistException.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/exception/NicknameNotExistException.java
@@ -1,0 +1,7 @@
+package softeer.carbook.domain.user.exception;
+
+public class NicknameNotExistException extends RuntimeException{
+    public NicknameNotExistException(String message) {
+        super(message);
+    }
+}

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/exception/idNotExistException.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/exception/idNotExistException.java
@@ -1,0 +1,7 @@
+package softeer.carbook.domain.user.exception;
+
+public class idNotExistException extends RuntimeException {
+    public idNotExistException(String message) {
+        super(message);
+    }
+}

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/model/User.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/model/User.java
@@ -13,7 +13,9 @@ public class User {
         this.nickname = nickname;
     }
 
-    public int getId() { return id; }
+    public int getId() {
+        return id;
+    }
 
     public String getEmail() {
         return email;

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/repository/UserRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/repository/UserRepository.java
@@ -47,10 +47,14 @@ public class UserRepository {
     }
 
     public String findEmailByNickname(String nickname) {
-        List<User> result = jdbcTemplate.query("select * from USER where nickname = ?", userRowMapper(), nickname);
+        List<String> result = jdbcTemplate.query("select email from USER where nickname = ?", emailRowMapper(), nickname);
         return result.stream().findAny().orElseThrow(
                 () -> new NicknameNotExistException("ERROR: Nickname not exist")
-        ).getEmail();
+        );
+    }
+
+    private RowMapper<String> emailRowMapper(){
+        return (rs, rowNum) -> rs.getString("email");
     }
 
     private RowMapper<User> userRowMapper(){

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/repository/UserRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/repository/UserRepository.java
@@ -6,6 +6,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 import softeer.carbook.domain.user.dto.SignupForm;
 import softeer.carbook.domain.user.exception.LoginEmailNotExistException;
+import softeer.carbook.domain.user.exception.NicknameNotExistException;
 import softeer.carbook.domain.user.model.User;
 
 import javax.sql.DataSource;
@@ -47,7 +48,9 @@ public class UserRepository {
 
     public String findEmailByNickname(String nickname) {
         List<User> result = jdbcTemplate.query("select * from USER where nickname = ?", userRowMapper(), nickname);
-        return result.stream().findAny().orElseThrow().getNickname();
+        return result.stream().findAny().orElseThrow(
+                () -> new NicknameNotExistException("ERROR: Nickname not exist")
+        ).getEmail();
     }
 
     private RowMapper<User> userRowMapper(){

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/repository/UserRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/repository/UserRepository.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 import softeer.carbook.domain.user.dto.SignupForm;
 import softeer.carbook.domain.user.exception.LoginEmailNotExistException;
 import softeer.carbook.domain.user.exception.NicknameNotExistException;
+import softeer.carbook.domain.user.exception.idNotExistException;
 import softeer.carbook.domain.user.model.User;
 
 import javax.sql.DataSource;
@@ -53,9 +54,21 @@ public class UserRepository {
         );
     }
 
+    public int findUserIdByNickname(String nickname) {
+        List<Integer> result = jdbcTemplate.query("select id from USER where nickname = ?", idRowMapper(), nickname);
+        return result.stream().findAny().orElseThrow(
+                () -> new idNotExistException("ERROR: Id not exist")
+        );
+    }
+
     private RowMapper<String> emailRowMapper(){
         return (rs, rowNum) -> rs.getString("email");
     }
+
+    private RowMapper<Integer> idRowMapper(){
+        return (rs, rowNum) -> rs.getInt("id");
+    }
+
 
     private RowMapper<User> userRowMapper(){
         return (rs, rowNum) -> {
@@ -68,6 +81,7 @@ public class UserRepository {
             return user;
         };
     }
+
 
 
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/repository/UserRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/repository/UserRepository.java
@@ -45,6 +45,11 @@ public class UserRepository {
         );
     }
 
+    public String findEmailByNickname(String nickname) {
+        List<User> result = jdbcTemplate.query("select * from USER where nickname = ?", userRowMapper(), nickname);
+        return result.stream().findAny().orElseThrow().getNickname();
+    }
+
     private RowMapper<User> userRowMapper(){
         return (rs, rowNum) -> {
             User user = new User(
@@ -56,5 +61,6 @@ public class UserRepository {
             return user;
         };
     }
+
 
 }


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #22 
- close #24 
- close #31 

## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
프로필 페이지에 들어온 해당 사용자를 쿠키를 통해 해당 사용자인지, 타인인지 조회하는 기능을 추가했습니다.
내 프로필 페이지인지와 타인의 프로필 페이지인지를 나누고 해당 사용자의 닉네임, 이메일, 작성한 게시글, 팔로워 수, 팔로잉 수를 불러와서 반환해주는 api를 구현했습니다. 타인의 페이지인 경우 로그인한 사람이 팔로우 했는지에 대한 여부도 같이 반환해주게 됩니다. 

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
