### PR TITLE
feat: 키워드를 통한 게시물 검색 시 사용하는 쿼리문 수정 및 리팩토링

### DIFF
--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/repository/HashtagRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/repository/HashtagRepository.java
@@ -24,7 +24,7 @@ public class HashtagRepository {
         List<Hashtag> hashtags = jdbcTemplate.query("select * from HASHTAG where tag = ?", tagRowMapper(), tag);
         return hashtags.stream()
                 .findAny()
-                .orElseThrow(() -> new HashtagNotExistException("해당 이름의 해시태그가 없습니다."));
+                .orElseThrow(() -> new HashtagNotExistException("ERROR: Hashtag not exist"));
     }
 
     private RowMapper<Hashtag> tagRowMapper() {

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/dto/PostsSearchResponse.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/dto/PostsSearchResponse.java
@@ -7,7 +7,27 @@ import java.util.List;
 public class PostsSearchResponse {
     private List<Image> images;
 
-    public PostsSearchResponse(List<Image> images){
-        this.images = images;
+    public PostsSearchResponse(PostsSearchResponseBuilder postsSearchResponseBuilder){
+        this.images = postsSearchResponseBuilder.images;
+    }
+
+    public List<Image> getImages() {
+        return images;
+    }
+
+    public static class PostsSearchResponseBuilder {
+        private List<Image> images;
+
+        public PostsSearchResponseBuilder() {
+        }
+
+        public PostsSearchResponseBuilder images(List<Image> images) {
+            this.images = images;
+            return this;
+        }
+
+        public PostsSearchResponse build() {
+            return new PostsSearchResponse(this);
+        }
     }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
@@ -5,7 +5,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 import softeer.carbook.domain.post.model.Image;
-import softeer.carbook.domain.post.model.Post;
 
 import javax.sql.DataSource;
 import java.util.List;
@@ -57,6 +56,28 @@ public class ImageRepository {
                         "ORDER BY create_date DESC",
                 imageRowMapper(), profileUserNickname);
         return images;
+    }
+
+    public List<Image> getImagesOfRecentPostsByTags(String[] tagNames, int size, int index) {
+        String conditionalStatement = createTagNameConditionalStatement(tagNames);
+        String query = "SELECT img.post_id, img.image_url " +
+                "FROM POST p " +
+                "INNER JOIN POST_HASHTAG ph ON p.id = ph.post_id " +
+                "INNER JOIN HASHTAG h ON ph.tag_id = h.id "+
+                "INNER JOIN IMAGE img ON p.id = img.post_id " +
+                "WHERE (" + conditionalStatement + ") ORDER BY p.create_date DESC LIMIT ?, ?";
+
+        return jdbcTemplate.query(query, imageRowMapper(), index, size);
+    }
+
+    private String createTagNameConditionalStatement(String[] tagNames) {
+        StringBuilder conditionalStatement = new StringBuilder();
+        for (String tagName: tagNames) {
+            conditionalStatement.append("h.tag = ").append(tagName);
+            conditionalStatement.append((" OR "));
+        }
+
+        return conditionalStatement.substring(0, conditionalStatement.length() - 4);
     }
 
     private RowMapper<Image> imageRowMapper(){

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/PostRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/PostRepository.java
@@ -4,11 +4,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
-import softeer.carbook.domain.post.model.Image;
 import softeer.carbook.domain.post.model.Post;
 
 import javax.sql.DataSource;
-import java.util.List;
 
 @Repository
 public class PostRepository {
@@ -17,26 +15,6 @@ public class PostRepository {
     @Autowired
     public PostRepository(DataSource dataSource) {
         this.jdbcTemplate = new JdbcTemplate(dataSource);
-    }
-
-    public List<Post> searchByHashtags(List<Integer> hashtagIds, int size, int index) {
-        String whereStatement = createWhereStatement(hashtagIds);
-        String query = "SELECT p.id, p.user_id, p.create_date, p.update_date, p.content " +
-                "FROM POST AS p " +
-                "INNER JOIN POST_HASHTAG AS ph " +
-                "ON p.id = ph.post_id WHERE " + whereStatement + " ORDER BY p.create_date DESC LIMIT ?, ?";
-
-        return jdbcTemplate.query(query, postRowMapper(), index, size);
-    }
-
-    private String createWhereStatement(List<Integer> hashtagIds) {
-        StringBuilder whereStatement = new StringBuilder();
-        for (int id : hashtagIds) {
-            whereStatement.append("ph.tag_id = ").append(id);
-            whereStatement.append((" OR "));
-        }
-
-        return whereStatement.substring(0, whereStatement.length() - 4);
     }
 
     /* deprecated

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -55,7 +55,9 @@ public class PostService {
         String[] tagNames = hashtags.split("\\+");
 
         List<Image> images = imageRepository.getImagesOfRecentPostsByTags(tagNames, POST_COUNT, index);
-        return new PostsSearchResponse(images);
+        return new PostsSearchResponse.PostsSearchResponseBuilder()
+                .images(images)
+                .build();
     }
 
     public MyProfileResponse myProfile(User loginUser) {

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -3,7 +3,6 @@ package softeer.carbook.domain.post.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import softeer.carbook.domain.follow.repository.FollowRepository;
-import softeer.carbook.domain.hashtag.model.Hashtag;
 import softeer.carbook.domain.hashtag.repository.HashtagRepository;
 import softeer.carbook.domain.post.dto.GuestPostsResponse;
 import softeer.carbook.domain.post.dto.LoginPostsResponse;
@@ -17,7 +16,6 @@ import softeer.carbook.domain.post.repository.PostRepository;
 import softeer.carbook.domain.user.model.User;
 import softeer.carbook.domain.user.repository.UserRepository;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -56,20 +54,7 @@ public class PostService {
     public PostsSearchResponse searchByTags(String hashtags, int index) {
         String[] tagNames = hashtags.split("\\+");
 
-        List<Integer> hashtagIds = new ArrayList<>();
-        for (String tagName : tagNames) {
-            Hashtag hashtag = hashtagRepository.findHashtagByName(tagName);
-            hashtagIds.add(hashtag.getId());
-        }
-
-        List<Post> posts = postRepository.searchByHashtags(hashtagIds, POST_COUNT, index);
-
-        List<Image> images = new ArrayList<>();
-        for (Post post : posts) {
-            Image image = imageRepository.getImageByPostId(post.getId());
-            images.add(image);
-        }
-
+        List<Image> images = imageRepository.getImagesOfRecentPostsByTags(tagNames, POST_COUNT, index);
         return new PostsSearchResponse(images);
     }
 


### PR DESCRIPTION
## 📌 이슈번호

- #34

## 📗 요구 사항과 구현 내용
### 키워드를 통한 게시물 검색 시 사용하는 쿼리문 수정
- PostService의 searchByTags() 메서드 내부 로직 수정
- ImageRepository에 getImagesOfRecentPostsByTags() 메서드 추가
    - POST, POST_HASHTAG, HASHTAG, IMAGE 테이블을 join하여 List<image> 반환
- 태그 이름 관련 조건절을 생성하는 createTagNameConditionalStatement() 메서드 추가
    - 인자로 주어진 태그 이름들을 " OR "로 연결하여 조건절 생성
- PostRepository의 searchByHashtags(), createWhereStatement() 메서드 삭제

### 리팩토링
- PostsSearchResponse 응답 객체에 Builder 패턴 적용

## 📖 구현 스크린샷

## 📖 PR 포인트 & 궁금한 점
PostService의 searchByTags() 메서드의 기존 로직은, hashtagRepository로 태그 이름에 해당하는 태그의 아이디를 가져오고, postRepository를 통해 해당 태그를 가지고 있는 post를 가져온 다음, ImageRepository를 통해 post의 아이디로 image를 가져왔습니다. 이 방식은 쿼리를 총 3번이나 보내기 때문에 조회 속도 저하 등의 문제가 있고, 그래서 쿼리를 3번 보내는 대신 `imageRepository.getImagesOfRecentPostsByTags()`를 호출하도록 수정하였습니다.
