### PR TITLE
feat: 닉네임 변경

### DIFF
--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/controller/UserController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/controller/UserController.java
@@ -6,12 +6,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.BindingResultUtils;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 import softeer.carbook.domain.user.dto.Message;
 import softeer.carbook.domain.user.dto.LoginForm;
-import softeer.carbook.domain.user.dto.NewNickNameForm;
+import softeer.carbook.domain.user.dto.ModifyNickNameForm;
 import softeer.carbook.domain.user.dto.SignupForm;
 import softeer.carbook.domain.user.exception.LoginEmailNotExistException;
 import softeer.carbook.domain.user.exception.NicknameNotExistException;
@@ -55,12 +53,12 @@ public class UserController {
     @PatchMapping("/profile/modify/{nickname}")
     public ResponseEntity<?> modifyNickname(
             @PathVariable("nickname") String nickname,
-            @Valid NewNickNameForm newNickNameForm,
+            @Valid ModifyNickNameForm modifyNickNameForm,
             HttpServletRequest httpServletRequest
     ){
         Message resultMsg = userService.modifyNickname(
                 nickname,
-                newNickNameForm.getNewNickname(),
+                modifyNickNameForm.getNewNickname(),
                 httpServletRequest);
         return Message.make200Response(resultMsg.getMessage());
     }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/controller/UserController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/controller/UserController.java
@@ -83,7 +83,7 @@ public class UserController {
         return Message.make400Response(emailDE.getMessage());
     }
 
-    // 회원가입 시 닉네임 중복 처리
+    // 회원가입, 닉네임 변경 시 닉네임 중복 처리
     @ExceptionHandler(NicknameDuplicateException.class)
     public ResponseEntity<Message> nicknameDuplicateException(NicknameDuplicateException nicknameDE){
         logger.debug(nicknameDE.getMessage());

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/controller/UserController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/controller/UserController.java
@@ -33,14 +33,14 @@ public class UserController {
 
     // 회원가입
     @PostMapping("/signup")
-    public ResponseEntity<Message> signup(@Valid SignupForm signupForm){
+    public ResponseEntity<Message> signup(@RequestBody @Valid SignupForm signupForm){
         Message resultMsg = userService.signup(signupForm);
         return Message.make200Response(resultMsg.getMessage());
     }
 
     // 로그인
     @PostMapping("/login")
-    public ResponseEntity<Message> login(@Valid LoginForm loginForm, HttpSession session) {
+    public ResponseEntity<Message> login(@RequestBody @Valid LoginForm loginForm, HttpSession session) {
         Message resultMsg = userService.login(loginForm, session);
         return Message.make200Response(resultMsg.getMessage());
     }
@@ -53,7 +53,7 @@ public class UserController {
     @PatchMapping("/profile/modify/{nickname}")
     public ResponseEntity<?> modifyNickname(
             @PathVariable("nickname") String nickname,
-            @Valid ModifyNickNameForm modifyNickNameForm,
+            @RequestBody @Valid ModifyNickNameForm modifyNickNameForm,
             HttpServletRequest httpServletRequest
     ){
         Message resultMsg = userService.modifyNickname(

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/controller/UserController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/controller/UserController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 import softeer.carbook.domain.user.dto.Message;
 import softeer.carbook.domain.user.dto.LoginForm;
+import softeer.carbook.domain.user.dto.NewNickNameForm;
 import softeer.carbook.domain.user.dto.SignupForm;
 import softeer.carbook.domain.user.exception.LoginEmailNotExistException;
 import softeer.carbook.domain.user.exception.SignupEmailDuplicateException;
@@ -47,6 +48,15 @@ public class UserController {
     // 로그아웃
 
     // 로그인한 사용자인지
+
+    // 닉네임 변경 ( 자신 프로필 페이지) > user 로
+    @PatchMapping("/profile/modify/{nickname}")
+    public ResponseEntity<?> modifyNickname(
+            @PathVariable("nickname") String nickname,
+            @Valid NewNickNameForm newNickNameForm){
+        Message resultMsg = userService.modifyNickname(nickname, newNickNameForm.getNewNickname());
+        return Message.make200Response(resultMsg.getMessage());
+    }
 
     // exception handling
 

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/controller/UserController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/controller/UserController.java
@@ -14,6 +14,7 @@ import softeer.carbook.domain.user.dto.LoginForm;
 import softeer.carbook.domain.user.dto.NewNickNameForm;
 import softeer.carbook.domain.user.dto.SignupForm;
 import softeer.carbook.domain.user.exception.LoginEmailNotExistException;
+import softeer.carbook.domain.user.exception.NicknameNotExistException;
 import softeer.carbook.domain.user.exception.SignupEmailDuplicateException;
 import softeer.carbook.domain.user.exception.NicknameDuplicateException;
 import softeer.carbook.domain.user.service.UserService;
@@ -95,6 +96,13 @@ public class UserController {
     public ResponseEntity<Message> loginEmailNotExistException(LoginEmailNotExistException emailNE){
         logger.debug(emailNE.getMessage());
         return Message.make400Response(emailNE.getMessage());
+    }
+
+    // 닉네임이 데이터베이스에 존재하지 않는 경우 처리
+    @ExceptionHandler(NicknameNotExistException.class)
+    public ResponseEntity<Message> nicknameNotExistException(NicknameNotExistException nicknameNE){
+        logger.debug(nicknameNE.getMessage());
+        return Message.make400Response(nicknameNE.getMessage());
     }
 
 

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/controller/UserController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/controller/UserController.java
@@ -18,6 +18,7 @@ import softeer.carbook.domain.user.exception.SignupEmailDuplicateException;
 import softeer.carbook.domain.user.exception.NicknameDuplicateException;
 import softeer.carbook.domain.user.service.UserService;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 
@@ -45,16 +46,21 @@ public class UserController {
         return Message.make200Response(resultMsg.getMessage());
     }
 
-    // 로그아웃
+    // todo 로그아웃
 
     // 로그인한 사용자인지
 
-    // 닉네임 변경 ( 자신 프로필 페이지) > user 로
+    // 닉네임 변경 ( 자신 프로필 페이지 )
     @PatchMapping("/profile/modify/{nickname}")
     public ResponseEntity<?> modifyNickname(
             @PathVariable("nickname") String nickname,
-            @Valid NewNickNameForm newNickNameForm){
-        Message resultMsg = userService.modifyNickname(nickname, newNickNameForm.getNewNickname());
+            @Valid NewNickNameForm newNickNameForm,
+            HttpServletRequest httpServletRequest
+    ){
+        Message resultMsg = userService.modifyNickname(
+                nickname,
+                newNickNameForm.getNewNickname(),
+                httpServletRequest);
         return Message.make200Response(resultMsg.getMessage());
     }
 

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/dto/ModifyNickNameForm.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/dto/ModifyNickNameForm.java
@@ -3,12 +3,12 @@ package softeer.carbook.domain.user.dto;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
-public class NewNickNameForm {
+public class ModifyNickNameForm {
     @Size(max = 16, message = "닉네임은 16자 이하여야 합니다.")
     @NotBlank(message = "닉네임을 입력해 주세요.")
     private final String newNickname;
 
-    public NewNickNameForm(String newNickname) {
+    public ModifyNickNameForm(String newNickname) {
         this.newNickname = newNickname;
     }
 

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/dto/NewNickNameForm.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/dto/NewNickNameForm.java
@@ -1,0 +1,18 @@
+package softeer.carbook.domain.user.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+public class NewNickNameForm {
+    @Size(max = 16, message = "닉네임은 16자 이하여야 합니다.")
+    @NotBlank(message = "닉네임을 입력해 주세요.")
+    private final String newNickname;
+
+    public NewNickNameForm(String newNickname) {
+        this.newNickname = newNickname;
+    }
+
+    public String getNewNickname() {
+        return newNickname;
+    }
+}

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/repository/UserRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/repository/UserRepository.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Repository;
 import softeer.carbook.domain.user.dto.SignupForm;
 import softeer.carbook.domain.user.exception.LoginEmailNotExistException;
 import softeer.carbook.domain.user.exception.NicknameNotExistException;
-import softeer.carbook.domain.user.exception.idNotExistException;
 import softeer.carbook.domain.user.model.User;
 
 import javax.sql.DataSource;
@@ -30,7 +29,7 @@ public class UserRepository {
         );
     }
 
-    public void modifyNicknameByNewNickname(String nickname, String newNickname) {
+    public void modifyNickname(String nickname, String newNickname) {
         jdbcTemplate.update("update USER SET nickname = ? where nickname = ?",
                 newNickname,
                 nickname

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/repository/UserRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/repository/UserRepository.java
@@ -27,7 +27,14 @@ public class UserRepository {
                 signupForm.getEmail(),
                 signupForm.getPassword(),
                 signupForm.getNickname()
-                );
+        );
+    }
+
+    public void modifyNicknameByNewNickname(String nickname, String newNickname) {
+        jdbcTemplate.update("update USER SET nickname = ? where nickname = ?",
+                newNickname,
+                nickname
+        );
     }
 
     public boolean isEmailDuplicated(String email) {

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
@@ -65,7 +65,14 @@ public class UserService {
         return (User) session.getAttribute("user");
     }
 
-    public Message modifyNickname(String nickname, String newNickname) {
+    public Message modifyNickname(String nickname, String newNickname, HttpServletRequest httpServletRequest) {
+        // 로그인 체크
+        if(!isLogin(httpServletRequest))
+            return new Message("ERROR: Session Has Expired");
+
+        // 새로운 닉네임 중복 체크
+
+
         return new Message("Nickname modified successfully");
     }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
@@ -80,7 +80,7 @@ public class UserService {
             throw new NicknameDuplicateException();
 
         // 새로운 닉네임 반영
-        userRepository.modifyNicknameByNewNickname(nickname, newNickname);
+        userRepository.modifyNickname(nickname, newNickname);
 
         return new Message("Nickname modified successfully");
     }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
@@ -71,7 +71,11 @@ public class UserService {
             return new Message("ERROR: Session Has Expired");
 
         // 새로운 닉네임 중복 체크
+        if(userRepository.isNicknameDuplicated(newNickname))
+            throw new NicknameDuplicateException();
 
+        // 새로운 닉네임 반영
+        userRepository.modifyNicknameByNewNickname(nickname, newNickname);
 
         return new Message("Nickname modified successfully");
     }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
@@ -65,4 +65,7 @@ public class UserService {
         return (User) session.getAttribute("user");
     }
 
+    public Message modifyNickname(String nickname, String newNickname) {
+        return new Message("Nickname modified successfully");
+    }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import softeer.carbook.domain.user.dto.Message;
 import softeer.carbook.domain.user.dto.LoginForm;
 import softeer.carbook.domain.user.dto.SignupForm;
+import softeer.carbook.domain.user.exception.NicknameNotExistException;
 import softeer.carbook.domain.user.exception.SignupEmailDuplicateException;
 import softeer.carbook.domain.user.exception.NicknameDuplicateException;
 import softeer.carbook.domain.user.model.User;
@@ -69,6 +70,10 @@ public class UserService {
         // 로그인 체크
         if(!isLogin(httpServletRequest))
             return new Message("ERROR: Session Has Expired");
+
+        // 기존 닉네임이 데이터베이스에 없다??
+        if(!userRepository.isNicknameDuplicated(nickname))
+            throw new NicknameNotExistException();
 
         // 새로운 닉네임 중복 체크
         if(userRepository.isNicknameDuplicated(newNickname))


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #26 

## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
닉네임 변경 로직을 구현했습니다. User 컨트롤러, 서비스, 리포지토리에 닉네임 변경 함수를 추가했고, dto 클래스를 추가했습니다.

닉네임 변경 서비스 로직은 먼저 로그인 세션이 만료되었는지 체크하고, 바꾸려는 기존 닉네임이 데이터베이스에 있는지 확인하고, 바꾸려는 닉네임이 데이터베이스에 있는 닉네임들과 중복되는지 체크하고, 새로운 닉네임을 반영하는 로직으로 구현했습니다. 기존 닉네임이 데이터베이스에 없을 경우 예외처리 했을 때 핸들링하는 로직이 컨트롤러에 구현이 되어 있지 않아서 그 부분까지 구현했습니다. 

테스트는 postman으로 예외처리 확인까지 모두 진행 완료하였습니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
