### PR TITLE
test: 해시태그를 통한 게시물 검색 기능 테스트 코드 작성

### DIFF
--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/exception/HashtagNotExistException.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/exception/HashtagNotExistException.java
@@ -1,7 +1,7 @@
 package softeer.carbook.domain.hashtag.exception;
 
-public class HashtagNotExistException extends RuntimeException{
-    public HashtagNotExistException(String message) {
-        super(message);
+public class HashtagNotExistException extends RuntimeException {
+    public HashtagNotExistException() {
+        super("ERROR: Hashtag not exist");
     }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/repository/HashtagRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/repository/HashtagRepository.java
@@ -24,7 +24,7 @@ public class HashtagRepository {
         List<Hashtag> hashtags = jdbcTemplate.query("select * from HASHTAG where tag = ?", tagRowMapper(), tag);
         return hashtags.stream()
                 .findAny()
-                .orElseThrow(() -> new HashtagNotExistException("ERROR: Hashtag not exist"));
+                .orElseThrow(() -> new HashtagNotExistException());
     }
 
     private RowMapper<Hashtag> tagRowMapper() {

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
@@ -73,7 +73,7 @@ public class ImageRepository {
     private String createTagNameConditionalStatement(String[] tagNames) {
         StringBuilder conditionalStatement = new StringBuilder();
         for (String tagName: tagNames) {
-            conditionalStatement.append("h.tag = ").append(tagName);
+            conditionalStatement.append("h.tag = '").append(tagName).append("'");
             conditionalStatement.append((" OR "));
         }
 

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -3,7 +3,6 @@ package softeer.carbook.domain.post.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import softeer.carbook.domain.follow.repository.FollowRepository;
-import softeer.carbook.domain.hashtag.repository.HashtagRepository;
 import softeer.carbook.domain.post.dto.GuestPostsResponse;
 import softeer.carbook.domain.post.dto.LoginPostsResponse;
 import softeer.carbook.domain.post.dto.PostsSearchResponse;
@@ -21,7 +20,6 @@ import java.util.List;
 public class PostService {
     private final PostRepository postRepository;
     private final ImageRepository imageRepository;
-    private final HashtagRepository hashtagRepository;
     private final UserRepository userRepository;
     private final FollowRepository followRepository;
     private final int POST_COUNT = 10;
@@ -30,12 +28,10 @@ public class PostService {
     public PostService(
             PostRepository postRepository,
             ImageRepository imageRepository,
-            HashtagRepository hashtagRepository,
             UserRepository userRepository,
             FollowRepository followRepository) {
         this.postRepository = postRepository;
         this.imageRepository = imageRepository;
-        this.hashtagRepository = hashtagRepository;
         this.userRepository = userRepository;
         this.followRepository = followRepository;
     }

--- a/backend/carbook/src/test/java/softeer/carbook/domain/post/service/PostServiceTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/post/service/PostServiceTest.java
@@ -1,0 +1,40 @@
+package softeer.carbook.domain.post.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import softeer.carbook.domain.post.dto.PostsSearchResponse;
+import softeer.carbook.domain.post.model.Image;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class PostServiceTest {
+
+    @Autowired
+    PostService postService;
+
+    @Test
+    @DisplayName("해시태그를 통한 게시물 검색 기능 테스트")
+    void searchByTags() {
+        String hashtags = "맑음+흐림";
+
+        PostsSearchResponse response = postService.searchByTags(hashtags, 0);
+        List<Image> result = response.getImages();
+
+        assertThat(result.size()).isEqualTo(4);
+        assertThat(result.get(0).getPostId()).isEqualTo(8);
+        assertThat(result.get(1).getPostId()).isEqualTo(6);
+        assertThat(result.get(2).getPostId()).isEqualTo(3);
+        assertThat(result.get(3).getPostId()).isEqualTo(2);
+        assertThat(result.get(0).getImageUrl()).isEqualTo("/eighth/image.jpg");
+        assertThat(result.get(1).getImageUrl()).isEqualTo("/sixth/image.jpg");
+        assertThat(result.get(2).getImageUrl()).isEqualTo("/third/image.jpg");
+        assertThat(result.get(3).getImageUrl()).isEqualTo("/second/image.jpg");
+    }
+}

--- a/backend/carbook/src/test/java/softeer/carbook/domain/user/service/UserServiceTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/user/service/UserServiceTest.java
@@ -1,6 +1,5 @@
 package softeer.carbook.domain.user.service;
 
-import com.mysql.cj.log.Log;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,24 +12,18 @@ import softeer.carbook.domain.user.dto.SignupForm;
 import softeer.carbook.domain.user.exception.LoginEmailNotExistException;
 import softeer.carbook.domain.user.exception.NicknameDuplicateException;
 import softeer.carbook.domain.user.exception.SignupEmailDuplicateException;
-import softeer.carbook.domain.user.repository.UserRepository;
-
-import javax.servlet.http.HttpSession;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
 class UserServiceTest {
     @Autowired
     UserService userService;
-    @Autowired
-    UserRepository userRepository;
 
     @Test
     @DisplayName("회원가입 성공 테스트")
-    void signup_success(){
+    void signup_success() {
         // given
         SignupForm signupForm = new SignupForm("test123@gmail.com", "testNickname", "testtest123");
         // when
@@ -41,14 +34,14 @@ class UserServiceTest {
 
     @Test
     @DisplayName("회원가입 중복된 이메일 입력될 경우")
-    void signupEmailDuplicate(){
+    void signupEmailDuplicate() {
         // given
         SignupForm signupForm = new SignupForm("test@gmail.com", "testNickname", "testtest123");
         String exceptionMsg = "";
         // when
         try {
             Message resultMsg = userService.signup(signupForm);
-        }catch (SignupEmailDuplicateException e){
+        } catch (SignupEmailDuplicateException e) {
             exceptionMsg = e.getMessage();
         }
         // then
@@ -57,14 +50,14 @@ class UserServiceTest {
 
     @Test
     @DisplayName("회원가입 중복된 닉네임 입력될 경우")
-    void signupNicknameDuplicate(){
+    void signupNicknameDuplicate() {
         // given
-        SignupForm signupForm = new SignupForm("test123@gmail.com", "carbook123", "testtest123");
+        SignupForm signupForm = new SignupForm("test123@gmail.com", "carbook123", "15번유저");
         String exceptionMsg = "";
         // when
-        try{
+        try {
             Message resultMsg = userService.signup(signupForm);
-        }catch (NicknameDuplicateException e){
+        } catch (NicknameDuplicateException e) {
             exceptionMsg = e.getMessage();
         }
         // then
@@ -75,7 +68,7 @@ class UserServiceTest {
     @DisplayName("로그인 성공 테스트")
     void loginSuccess() {
         // given
-        LoginForm loginForm = new LoginForm("test@gmail.com", "카북화이팅");
+        LoginForm loginForm = new LoginForm("test@gmail.com", "carbook");
         // when
         Message resultMsg = userService.login(loginForm, new MockHttpSession());
         // then
@@ -89,9 +82,9 @@ class UserServiceTest {
         LoginForm loginForm = new LoginForm("test123@gmail.com", "카북화이팅");
         String exceptionMsg = "";
         // when
-        try{
+        try {
             Message resultMsg = userService.login(loginForm, new MockHttpSession());
-        }catch (LoginEmailNotExistException e){
+        } catch (LoginEmailNotExistException e) {
             exceptionMsg = e.getMessage();
         }
         // then


### PR DESCRIPTION
## 📌 이슈번호
- #122 

## 📗 요구 사항과 구현 내용
### 해시태그를 통한 게시물 검색 기능 테스트 코드 작성
- 외부 DB에 저장되어있는 샘플 데이터로 테스트 실행
- 테스트 코드를 작성하여 테스트 실행 중 쿼리문을 잘못 작성한 것을 발견하였으며, 쿼리문에서 문자열을 사용할 때 ''로 감싸도록 수정

### 기타 수정사항
- `HashtagNotExistException`의 에러 메시지를 외부에서 인자로 주는 것이 아니라 `exception` 클래스에서 관리하도록 변경
- `UserServiceTest`의 테스트 실패하는 메서드를 성공하도록 변수의 값 수정

## 📖 구현 스크린샷

## 📖 PR 포인트 & 궁금한 점