### PR TITLE
feat: 비밀번호 변경

### DIFF
--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/controller/PostController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/controller/PostController.java
@@ -32,7 +32,7 @@ public class PostController {
 
     @GetMapping("/posts/m")
     public ResponseEntity<?> getPosts(@RequestParam int index, HttpServletRequest httpServletRequest){
-        if (userService.isLogin(httpServletRequest))
+        if (userService.isLogin(httpServletRequest.getSession(false)))
             return getLoginPosts(index, httpServletRequest);
         return getGuestPosts(index);
     }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/controller/UserController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/controller/UserController.java
@@ -63,7 +63,7 @@ public class UserController {
     // 비밀번호 변경 ( 자신 프로필 페이지 )
     @PatchMapping("/profile/modify/password")
     public ResponseEntity<Message> modifyPassword(
-            @Valid ModifyPasswordForm modifyPasswordForm,
+            @RequestBody @Valid ModifyPasswordForm modifyPasswordForm,
             HttpServletRequest httpServletRequest
     ){
         Message resultMsg = userService.modifyPassword(

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/controller/UserController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/controller/UserController.java
@@ -7,10 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
-import softeer.carbook.domain.user.dto.Message;
-import softeer.carbook.domain.user.dto.LoginForm;
-import softeer.carbook.domain.user.dto.ModifyNickNameForm;
-import softeer.carbook.domain.user.dto.SignupForm;
+import softeer.carbook.domain.user.dto.*;
 import softeer.carbook.domain.user.exception.LoginEmailNotExistException;
 import softeer.carbook.domain.user.exception.NicknameNotExistException;
 import softeer.carbook.domain.user.exception.SignupEmailDuplicateException;
@@ -59,6 +56,18 @@ public class UserController {
         Message resultMsg = userService.modifyNickname(
                 nickname,
                 modifyNickNameForm.getNewNickname(),
+                httpServletRequest);
+        return Message.make200Response(resultMsg.getMessage());
+    }
+
+    // 비밀번호 변경 ( 자신 프로필 페이지 )
+    @PatchMapping("/profile/modify/password")
+    public ResponseEntity<Message> modifyPassword(
+            @Valid ModifyPasswordForm modifyPasswordForm,
+            HttpServletRequest httpServletRequest
+    ){
+        Message resultMsg = userService.modifyPassword(
+                modifyPasswordForm,
                 httpServletRequest);
         return Message.make200Response(resultMsg.getMessage());
     }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/controller/UserController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/controller/UserController.java
@@ -8,10 +8,7 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import softeer.carbook.domain.user.dto.*;
-import softeer.carbook.domain.user.exception.LoginEmailNotExistException;
-import softeer.carbook.domain.user.exception.NicknameNotExistException;
-import softeer.carbook.domain.user.exception.SignupEmailDuplicateException;
-import softeer.carbook.domain.user.exception.NicknameDuplicateException;
+import softeer.carbook.domain.user.exception.*;
 import softeer.carbook.domain.user.service.UserService;
 
 import javax.servlet.http.HttpServletRequest;
@@ -110,6 +107,13 @@ public class UserController {
     public ResponseEntity<Message> nicknameNotExistException(NicknameNotExistException nicknameNE){
         logger.debug(nicknameNE.getMessage());
         return Message.make400Response(nicknameNE.getMessage());
+    }
+
+    // 로그인 상태가 아닌 경우 처리
+    @ExceptionHandler(NotLoginStatementException.class)
+    public ResponseEntity<Message> notLoginStatementException(NotLoginStatementException notLoginE){
+        logger.debug(notLoginE.getMessage());
+        return Message.make400Response(notLoginE.getMessage());
     }
 
 

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/dto/ModifyPasswordForm.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/dto/ModifyPasswordForm.java
@@ -1,0 +1,24 @@
+package softeer.carbook.domain.user.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+public class ModifyPasswordForm {
+    private final String password;
+    @Size(max = 16, message = "비밀번호는 16자 이하여야 합니다.")
+    @NotBlank(message = "비밀번호를 입력해 주세요.")
+    private final String newPassword;
+
+    public ModifyPasswordForm(String password, String newPassword) {
+        this.password = password;
+        this.newPassword = newPassword;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
+    }
+}

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/dto/ModifyPasswordForm.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/dto/ModifyPasswordForm.java
@@ -4,6 +4,8 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
 public class ModifyPasswordForm {
+    @Size(max = 16, message = "비밀번호는 16자 이하여야 합니다.")
+    @NotBlank(message = "비밀번호를 입력해 주세요.")
     private final String password;
     @Size(max = 16, message = "비밀번호는 16자 이하여야 합니다.")
     @NotBlank(message = "비밀번호를 입력해 주세요.")

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/exception/IdNotExistException.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/exception/IdNotExistException.java
@@ -1,0 +1,7 @@
+package softeer.carbook.domain.user.exception;
+
+public class IdNotExistException extends RuntimeException {
+    public IdNotExistException() {
+        super("ERROR: ID not exist");
+    }
+}

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/exception/NotLoginStatementException.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/exception/NotLoginStatementException.java
@@ -1,0 +1,7 @@
+package softeer.carbook.domain.user.exception;
+
+public class NotLoginStatementException extends RuntimeException{
+    public NotLoginStatementException() {
+        super("ERROR: Session Has Expired");
+    }
+}

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/exception/idNotExistException.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/exception/idNotExistException.java
@@ -1,7 +1,0 @@
-package softeer.carbook.domain.user.exception;
-
-public class idNotExistException extends RuntimeException {
-    public idNotExistException() {
-        super("ERROR: ID not exist");
-    }
-}

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/repository/UserRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/repository/UserRepository.java
@@ -36,6 +36,13 @@ public class UserRepository {
         );
     }
 
+    public void modifyPassword(String password, String newPassword) {
+        jdbcTemplate.update("update USER SET password = ? where password = ?",
+                newPassword,
+                password
+        );
+    }
+
     public boolean isEmailDuplicated(String email) {
         List<User> result = jdbcTemplate.query("select * from USER where email = ?", userRowMapper(), email);
         return !result.isEmpty();

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/repository/UserRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/repository/UserRepository.java
@@ -5,6 +5,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 import softeer.carbook.domain.user.dto.SignupForm;
+import softeer.carbook.domain.user.exception.IdNotExistException;
 import softeer.carbook.domain.user.exception.LoginEmailNotExistException;
 import softeer.carbook.domain.user.exception.NicknameNotExistException;
 import softeer.carbook.domain.user.model.User;
@@ -51,6 +52,13 @@ public class UserRepository {
     public boolean isNicknameDuplicated(String nickname) {
         List<User> result = jdbcTemplate.query("select * from USER where nickname = ?", userRowMapper(), nickname);
         return !result.isEmpty();
+    }
+
+    public User findUserById(int id){
+        List<User> result = jdbcTemplate.query("select * from USER where id = ?", userRowMapper(), id);
+        return result.stream().findAny().orElseThrow(
+                () -> new IdNotExistException()
+        );
     }
 
     public User findUserByEmail(String email){

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
@@ -59,7 +59,7 @@ public class UserService {
         HttpSession session = httpServletRequest.getSession(false);
 
         // 로그인 상태 확인
-        checkLogin(session);
+        checkLoginException(session);
 
         // 세션으로부터 userId를 받아서 user 조회
         return userRepository.findUserById(getUserIdBySession(session));
@@ -67,7 +67,7 @@ public class UserService {
 
     public Message modifyNickname(String nickname, String newNickname, HttpServletRequest httpServletRequest) {
         // 로그인 체크
-        checkLogin(httpServletRequest.getSession(false));
+        checkLoginException(httpServletRequest.getSession(false));
 
         // 기존 닉네임이 데이터베이스에 없다??
         if(!userRepository.isNicknameDuplicated(nickname))
@@ -101,7 +101,7 @@ public class UserService {
         return (int) session.getAttribute("user");
     }
 
-    public void checkLogin(HttpSession session){
+    public void checkLoginException(HttpSession session){
         if(!isLogin(session)) throw new NotLoginStatementException();
     }
 

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import softeer.carbook.domain.user.dto.Message;
 import softeer.carbook.domain.user.dto.LoginForm;
+import softeer.carbook.domain.user.dto.ModifyPasswordForm;
 import softeer.carbook.domain.user.dto.SignupForm;
 import softeer.carbook.domain.user.exception.NicknameNotExistException;
 import softeer.carbook.domain.user.exception.SignupEmailDuplicateException;
@@ -83,5 +84,9 @@ public class UserService {
         userRepository.modifyNickname(nickname, newNickname);
 
         return new Message("Nickname modified successfully");
+    }
+
+    public Message modifyPassword(ModifyPasswordForm modifyPasswordForm, HttpServletRequest httpServletRequest) {
+        return new Message("Password modified successfully");
     }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
@@ -92,10 +92,8 @@ public class UserService {
             return new Message("ERROR: Session Has Expired");
 
         // 기존 비밀번호와 맞는지 확인
-        // 세션에서 로그인 유저 id 불러오기
-        int userId = getUserIdBySession(httpServletRequest.getSession(false));
-        // 불러온 id를 통해 유저 불러오기
-        User modifyUser = userRepository.findUserById(userId);
+        // 세션을 통해 유저 불러오기
+        User modifyUser = findLoginedUser(httpServletRequest);
         if(!checkPassword(modifyUser, modifyPasswordForm.getPassword()))
             // 기존 비밀번호와 맞지 않을 경우 = 패스워드 불일치
             return new Message("ERROR: Password not match");

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
@@ -44,8 +44,8 @@ public class UserService {
 
     public Message login(LoginForm loginForm, HttpSession session) {
         User user = userRepository.findUserByEmail(loginForm.getEmail());
-        if(isLoginSuccess(user, loginForm)) {
-            // 성공했을 경우 세션에 추가
+        if(checkPassword(user, loginForm.getPassword())) {
+            // 로그인 성공했을 경우 세션에 추가
             session.setAttribute("user", user);
             // 세션에 추가 후 성공 메세지 반환
             return new Message("Login Success");
@@ -54,8 +54,8 @@ public class UserService {
         return new Message("ERROR: Password not match");
     }
 
-    private boolean isLoginSuccess(User user, LoginForm loginForm){
-        return user.getPassword().equals(loginForm.getPassword());
+    private boolean checkPassword(User user, String password){
+        return user.getPassword().equals(password);
     }
 
     public boolean isLogin(HttpServletRequest httpServletRequest){
@@ -90,6 +90,12 @@ public class UserService {
         // 로그인 체크
         if(!isLogin(httpServletRequest))
             return new Message("ERROR: Session Has Expired");
+
+        // 기존 비밀번호와 맞는지 확인
+        User modifyUser = findLoginedUser(httpServletRequest);
+        if(!checkPassword(modifyUser, modifyPasswordForm.getPassword()))
+            // 기존 비밀번호와 맞지 않을 경우 = 패스워드 불일치
+            return new Message("ERROR: Password not match");
 
         // 새로운 비밀번호 반영
         userRepository.modifyPassword(modifyPasswordForm.getPassword(), modifyPasswordForm.getNewPassword());

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
@@ -87,6 +87,13 @@ public class UserService {
     }
 
     public Message modifyPassword(ModifyPasswordForm modifyPasswordForm, HttpServletRequest httpServletRequest) {
+        // 로그인 체크
+        if(!isLogin(httpServletRequest))
+            return new Message("ERROR: Session Has Expired");
+
+        // 새로운 비밀번호 반영
+        userRepository.modifyPassword(modifyPasswordForm.getPassword(), modifyPasswordForm.getNewPassword());
+
         return new Message("Password modified successfully");
     }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/user/service/UserService.java
@@ -46,7 +46,7 @@ public class UserService {
         User user = userRepository.findUserByEmail(loginForm.getEmail());
         if(checkPassword(user, loginForm.getPassword())) {
             // 로그인 성공했을 경우 세션에 추가
-            session.setAttribute("user", user);
+            session.setAttribute("user", user.getId());
             // 세션에 추가 후 성공 메세지 반환
             return new Message("Login Success");
         }
@@ -63,8 +63,8 @@ public class UserService {
     }
 
     public User findLoginedUser(HttpServletRequest httpServletRequest){
-        HttpSession session = httpServletRequest.getSession(false);
-        return (User) session.getAttribute("user");
+        int userId = getUserIdBySession(httpServletRequest.getSession(false));
+        return userRepository.findUserById(userId);
     }
 
     public Message modifyNickname(String nickname, String newNickname, HttpServletRequest httpServletRequest) {
@@ -92,7 +92,10 @@ public class UserService {
             return new Message("ERROR: Session Has Expired");
 
         // 기존 비밀번호와 맞는지 확인
-        User modifyUser = findLoginedUser(httpServletRequest);
+        // 세션에서 로그인 유저 id 불러오기
+        int userId = getUserIdBySession(httpServletRequest.getSession(false));
+        // 불러온 id를 통해 유저 불러오기
+        User modifyUser = userRepository.findUserById(userId);
         if(!checkPassword(modifyUser, modifyPasswordForm.getPassword()))
             // 기존 비밀번호와 맞지 않을 경우 = 패스워드 불일치
             return new Message("ERROR: Password not match");
@@ -101,5 +104,9 @@ public class UserService {
         userRepository.modifyPassword(modifyPasswordForm.getPassword(), modifyPasswordForm.getNewPassword());
 
         return new Message("Password modified successfully");
+    }
+
+    private int getUserIdBySession(HttpSession session){
+        return (int) session.getAttribute("user");
     }
 }


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #29 

## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
비밀번호 변경 로직을 구현하였습니다.

먼저 로그인을 한 사용자인지 체크하고, 기존 비밀번호와 입력한 비밀번호가 맞는지 확인하는 과정을 거친 후에 새로운 비밀번호를 반영하게 됩니다. 이 기능을 구현하는 과정에서 세션에 user를 저장해서 세션을 통해 user정보를 꺼내오는 로직을 다시 생각해 보게 되었고, 심각한 오류라고 생각하여 세션에 user id만 저장하고 저장한 user id를 통해 db에서 그때그때 user 정보를 불러오도록 수정하였습니다. 

포스트맨을 통해 비밀번호 변경 성공, 로그인 세션 만료, 비밀번호 변경 실패 모두 테스트 완료했습니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
