### PR TITLE
feat: 해시태그 검색 기능 구현

### DIFF
--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/controller/HashtagController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/controller/HashtagController.java
@@ -1,6 +1,29 @@
 package softeer.carbook.domain.hashtag.controller;
 
-public class HashtagController {
-    // 메인 페이지에서 해시태그 검색
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import softeer.carbook.domain.hashtag.dto.HashtagSearchResponse;
+import softeer.carbook.domain.hashtag.service.HashtagService;
 
+@RestController
+public class HashtagController {
+    private final HashtagService hashtagService;
+
+    @Autowired
+    public HashtagController(HashtagService hashtagService) {
+        this.hashtagService = hashtagService;
+    }
+
+    // 모든 태그 검색
+
+    // 해시태그 검색
+    @GetMapping("/search/hashtag/")
+    public ResponseEntity<HashtagSearchResponse> searchHashtag(@RequestParam String keyword) {
+        HashtagSearchResponse hashtagSearchResponse = hashtagService.searchHashTag(keyword);
+        return new ResponseEntity<>(hashtagSearchResponse, HttpStatus.OK);
+    }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/dto/HashtagSearchResponse.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/dto/HashtagSearchResponse.java
@@ -1,0 +1,34 @@
+package softeer.carbook.domain.hashtag.dto;
+
+import softeer.carbook.domain.hashtag.model.Hashtag;
+
+import java.util.List;
+
+public class HashtagSearchResponse {
+    private List<Hashtag> hashtags;
+
+    public HashtagSearchResponse(HashtagSearchResponseBuilder builder) {
+        this.hashtags = builder.hashtags;
+    }
+
+    public List<Hashtag> getHashtags() {
+        return hashtags;
+    }
+
+    public static class HashtagSearchResponseBuilder {
+
+        private List<Hashtag> hashtags;
+
+        public HashtagSearchResponseBuilder() {
+        }
+
+        public HashtagSearchResponseBuilder hashtags(List<Hashtag> hashtags) {
+            this.hashtags = hashtags;
+            return this;
+        }
+
+        public HashtagSearchResponse build() {
+            return new HashtagSearchResponse(this);
+        }
+    }
+}

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/repository/HashtagRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/repository/HashtagRepository.java
@@ -21,10 +21,14 @@ public class HashtagRepository {
     }
 
     public Hashtag findHashtagByName(String tag) {
-        List<Hashtag> hashtags = jdbcTemplate.query("select * from HASHTAG where tag = ?", tagRowMapper(), tag);
+        List<Hashtag> hashtags = jdbcTemplate.query("SELECT * FROM HASHTAG WHERE tag = ?", tagRowMapper(), tag);
         return hashtags.stream()
                 .findAny()
                 .orElseThrow(() -> new HashtagNotExistException());
+    }
+
+    public List<Hashtag> searchHashtagByPrefix(String keyword) {
+        return jdbcTemplate.query("SELECT h.id, h.tag FROM HASHTAG h WHERE tag LIKE '" + keyword + "%'", tagRowMapper());
     }
 
     private RowMapper<Hashtag> tagRowMapper() {

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/repository/HashtagRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/repository/HashtagRepository.java
@@ -21,7 +21,7 @@ public class HashtagRepository {
     }
 
     public Hashtag findHashtagByName(String tag) {
-        List<Hashtag> hashtags = jdbcTemplate.query("SELECT * FROM HASHTAG WHERE tag = ?", tagRowMapper(), tag);
+        List<Hashtag> hashtags = jdbcTemplate.query("SELECT h.id, h.tag FROM HASHTAG h WHERE tag = ?", tagRowMapper(), tag);
         return hashtags.stream()
                 .findAny()
                 .orElseThrow(() -> new HashtagNotExistException());

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/service/HashtagService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/service/HashtagService.java
@@ -1,4 +1,28 @@
 package softeer.carbook.domain.hashtag.service;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import softeer.carbook.domain.hashtag.dto.HashtagSearchResponse;
+import softeer.carbook.domain.hashtag.model.Hashtag;
+import softeer.carbook.domain.hashtag.repository.HashtagRepository;
+
+import java.util.List;
+
+@Service
 public class HashtagService {
+
+    private final HashtagRepository hashtagRepository;
+
+    @Autowired
+    public HashtagService(HashtagRepository hashtagRepository) {
+        this.hashtagRepository = hashtagRepository;
+    }
+
+    public HashtagSearchResponse searchHashTag(String keyword) {
+        List<Hashtag> hashtags = hashtagRepository.searchHashtagByPrefix(keyword);
+
+        return new HashtagSearchResponse.HashtagSearchResponseBuilder()
+                .hashtags(hashtags)
+                .build();
+    }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -52,7 +52,7 @@ public class PostService {
     }
 
     public PostsSearchResponse searchByTags(String hashtags, int index) {
-        String[] tagNames = hashtags.split("\\+");
+        String[] tagNames = hashtags.split(" ");
 
         List<Image> images = imageRepository.getImagesOfRecentPostsByTags(tagNames, POST_COUNT, index);
         return new PostsSearchResponse.PostsSearchResponseBuilder()

--- a/backend/carbook/src/test/java/softeer/carbook/domain/post/service/PostServiceTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/post/service/PostServiceTest.java
@@ -2,30 +2,16 @@ package softeer.carbook.domain.post.service;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
-import softeer.carbook.domain.follow.repository.FollowRepository;
 import softeer.carbook.domain.post.dto.GuestPostsResponse;
 import softeer.carbook.domain.post.dto.LoginPostsResponse;
-import softeer.carbook.domain.post.model.Image;
-import softeer.carbook.domain.user.controller.UserController;
-import softeer.carbook.domain.user.model.User;
-import softeer.carbook.domain.user.repository.UserRepository;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 import softeer.carbook.domain.post.dto.PostsSearchResponse;
 import softeer.carbook.domain.post.model.Image;
+import softeer.carbook.domain.user.model.User;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -71,7 +57,7 @@ class PostServiceTest {
 
     @Test
     @DisplayName("더 이상 불러올 게시글이 없을 때 테스트")
-    void getNoPostsTest(){
+    void getNoPostsTest() {
         //given
         int index = 10;
         //when
@@ -88,7 +74,7 @@ class PostServiceTest {
     void getRecentFollowerPostsTest() {
         //given
         int index = 0;
-        User user = new User(15,"user15@exam.com","15번유저","pw15");
+        User user = new User(15, "user15@exam.com", "15번유저", "pw15");
         //when
         LoginPostsResponse loginPostsResponse = postService.getRecentFollowerPosts(index, user);
         //then
@@ -101,10 +87,10 @@ class PostServiceTest {
 
     @Test
     @DisplayName("팔로잉중인 게시글이 없는 경우 테스트")
-    void getNoFollowingPostsTest(){
+    void getNoFollowingPostsTest() {
         //given
         int index = 0;
-        User user = new User(17,"user17@email.com","사용자17","pw17");
+        User user = new User(17, "user17@email.com", "사용자17", "pw17");
         //when
         LoginPostsResponse loginPostsResponse = postService.getRecentFollowerPosts(index, user);
         //then
@@ -118,7 +104,7 @@ class PostServiceTest {
     @Test
     @DisplayName("해시태그를 통한 게시물 검색 기능 테스트")
     void searchByTags() {
-        String hashtags = "맑음+흐림";
+        String hashtags = "맑음 흐림";
 
         PostsSearchResponse response = postService.searchByTags(hashtags, 0);
         List<Image> result = response.getImages();


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- #141

## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
### 태그 검색 util API 중 해시태그 검색 API를 구현했습니다.
- 해시태그 검색의 응답에 사용할 `HashtagSearchResponse` 응답 객체 생성
- `HashtagRepository`에 접두어로 해시태그를 검색하는 searchHashtagByPrefix() 메서드 구현
- `HashtagService` 클래스 생성 및 해시태그 검색 기능 구현
    - searchHashTag(): 인자로 주어진 키워드로 시작하는 해시태그를 검색하여 HashtagSearchResponse를 반환
- `HashtagController` 클래스 생성 및 해시태그 검색 API 구현]
    - searchHashTag(): 쿼리 파라미터로 주어진 키워드로 시작하는 해시태그를 검색하여 그 결과에 대한 응답을 반환

### 수정사항
- SpringController는 매개 변수의 "+" 문자를 공백으로 대체하기 때문에, `PostService`의 `searchByTags()`에서 태그 이름을 구분하는 구분자를 "+"에서 공백으로 변경
    - `PostService` 로직 변경에 따라 `PostServiceTest`의 테스트 코드도 변경

## 📖 구현 스크린샷

## 📖 PR 포인트 & 궁금한 점
