### PR TITLE
refactor: 팔로우/언팔로우 방식 soft delete로 변경

### DIFF
--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
@@ -31,7 +31,8 @@ public class ImageRepository {
     public List<Image> getImagesOfRecentFollowingPosts(int size, int index, int followerId){
         return jdbcTemplate.query("SELECT img.post_id, img.image_url " +
                 "FROM POST AS p, IMAGE AS img, FOLLOW AS f " +
-                        "where f.follower_id = ? " +
+                        "where f.is_deleted = false " +
+                        "and f.follower_id = ? " +
                         "and f.following_id = p.user_id " +
                         "and p.id = img.post_id " +
                 "ORDER BY p.create_date DESC LIMIT ?, ?",


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #140 

## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
새로운 데이터베이스에 default값이 false인 is_deleted boolean column을 추가해야 합니다.
upsert 쿼리 수행을 위해 follower_id와 following_id의 복합키 설정이 필요합니다.
is_deleted를 활용하도록 followRepository, imageRepository를 일부 변경하였습니다.
신규 팔로우인 경우 insert, 과거 팔로우했었던 경우 update 수행하는 upsert 로직으로 변경하였습니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
