### PR TITLE
test:  나의 프로필 페이지, 타인의 프로필 페이지 테스트 코드 작성

### DIFF
--- a/backend/carbook/src/test/java/softeer/carbook/domain/post/service/PostServiceTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/post/service/PostServiceTest.java
@@ -5,9 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
-import softeer.carbook.domain.post.dto.GuestPostsResponse;
-import softeer.carbook.domain.post.dto.LoginPostsResponse;
-import softeer.carbook.domain.post.dto.PostsSearchResponse;
+import softeer.carbook.domain.post.dto.*;
 import softeer.carbook.domain.post.model.Image;
 import softeer.carbook.domain.user.model.User;
 
@@ -105,19 +103,66 @@ class PostServiceTest {
     @DisplayName("해시태그를 통한 게시물 검색 기능 테스트")
     void searchByTags() {
         String hashtags = "맑음 흐림";
+        List<Image> expectedResult = new ArrayList<Image>(List.of(
+                new Image(8, "/eighth/image.jpg"),
+                new Image(6, "/sixth/image.jpg"),
+                new Image(3, "/third/image.jpg"),
+                new Image(2, "/second/image.jpg")
+        ));
 
         PostsSearchResponse response = postService.searchByTags(hashtags, 0);
         List<Image> result = response.getImages();
 
-        assertThat(result.size()).isEqualTo(4);
-        assertThat(result.get(0).getPostId()).isEqualTo(8);
-        assertThat(result.get(1).getPostId()).isEqualTo(6);
-        assertThat(result.get(2).getPostId()).isEqualTo(3);
-        assertThat(result.get(3).getPostId()).isEqualTo(2);
-        assertThat(result.get(0).getImageUrl()).isEqualTo("/eighth/image.jpg");
-        assertThat(result.get(1).getImageUrl()).isEqualTo("/sixth/image.jpg");
-        assertThat(result.get(2).getImageUrl()).isEqualTo("/third/image.jpg");
-        assertThat(result.get(3).getImageUrl()).isEqualTo("/second/image.jpg");
+        assertThat(result).usingRecursiveComparison().isEqualTo(expectedResult);
+    }
+
+    @Test
+    @DisplayName("나의 프로필 페이지 테스트")
+    void myProfile() {
+        String email = "user17@email.com";
+        String nickname = "사용자17";
+        User user = new User(17, email, nickname, "pw17");
+        List<Image> images = new ArrayList<Image>(List.of(
+                new Image(8, "/eighth/image.jpg"),
+                new Image(7, "/seventh/image.jpg")
+        ));
+        MyProfileResponse expectedResult = new MyProfileResponse.MyProfileResponseBuilder()
+                .nickname(nickname)
+                .email(email)
+                .follower(3)
+                .following(0)
+                .images(images)
+                .build();
+
+        MyProfileResponse result = postService.myProfile(user);
+
+        assertThat(result).usingRecursiveComparison().isEqualTo(expectedResult);
+    }
+
+    @Test
+    @DisplayName("타인의 프로필 페이지 테스트")
+    void otherProfile() {
+        String email = "user15@exam.com";
+        String nickname = "15번유저";
+        User loginUser = new User(15, email, nickname, "pw15");
+        String profileUserNickname = "사용자17";
+        String profileUserEmail = "user17@email.com";
+        List<Image> images = new ArrayList<Image>(List.of(
+                new Image(8, "/eighth/image.jpg"),
+                new Image(7, "/seventh/image.jpg")
+        ));
+        OtherProfileResponse expectedResult = new OtherProfileResponse.OtherProfileResponseBuilder()
+                .nickname(profileUserNickname)
+                .email(profileUserEmail)
+                .follow(true)
+                .follower(3)
+                .following(0)
+                .images(images)
+                .build();
+
+        OtherProfileResponse result = postService.otherProfile(loginUser, profileUserNickname);
+
+        assertThat(result).usingRecursiveComparison().isEqualTo(expectedResult);
     }
 
 }


### PR DESCRIPTION
## 📌 이슈번호

- #134

## 📗 요구 사항과 구현 내용
- `myProfile()`: 나의 프로필 페이지인 경우 프로필 정보(닉네임, 이메일, 작성한 게시글, 팔로워 수, 팔로잉 수)를 조회하는 기능을 테스트하는 코드
- `otherProfile()`: 타인의 프로필 페이지인 경우 프로필 정보(닉네임, 이메일, 작성한 게시글, 팔로워 수, 팔로잉 수)와 팔로우 여부를 조회하는 테스트 코드
- 해시태그를 통한 게시물 검색 기능 테스트 코드(`searchByTags()`) 리팩토링

## 📖 구현 스크린샷

## 📖 PR 포인트 & 궁금한 점