### PR TITLE
chore: store 구조 모듈화

### DIFF
--- a/frontend/carbook/src/components/Home/HashtagList.ts
+++ b/frontend/carbook/src/components/Home/HashtagList.ts
@@ -1,12 +1,11 @@
 import { Component } from '@/core';
-import { tagStore } from '@/store';
+import { tagStore } from '@/store/tagStore';
 import { actionType } from '@/store/tagStore';
 import { getClosest, getTagIcon } from '@/utils';
 
 export default class HashTagList extends Component {
   setup(): void {
-    tagStore.subscribe(this.render.bind(this));
-    this.setState(tagStore.getState());
+    tagStore.subscribe(this, this.render.bind(this));
     this.onClickHandler();
   }
   template(): string {
@@ -38,7 +37,7 @@ export default class HashTagList extends Component {
 
       tagStore.dispach({
         type: actionType.DELETE_TAG,
-        tag: { id },
+        payload: { id },
       });
     });
   }

--- a/frontend/carbook/src/components/Home/PostList.ts
+++ b/frontend/carbook/src/components/Home/PostList.ts
@@ -1,9 +1,9 @@
 import { Component } from '@/core';
-import { tagStore } from '@/store';
+import { tagStore } from '@/store/tagStore';
 
 export default class PostList extends Component {
   setup(): void {
-    tagStore.subscribe(this.render.bind(this));
+    tagStore.subscribe(this, this.render.bind(this));
   }
   template(): string {
     const { postList } = this.props;

--- a/frontend/carbook/src/components/Home/SearchForm.ts
+++ b/frontend/carbook/src/components/Home/SearchForm.ts
@@ -1,8 +1,8 @@
 import { basicAPI } from '@/api';
 import { categoryMap } from '@/constants/category';
 import { Component } from '@/core';
-import { CategoryType, IHashTag } from '@/interfaces';
-import { tagStore } from '@/store';
+import { IHashTag } from '@/interfaces';
+import { tagStore } from '@/store/tagStore';
 import { actionType } from '@/store/tagStore';
 import { getClosest, getTagIcon } from '@/utils';
 import Category from './Category';
@@ -91,14 +91,10 @@ export default class SearchForm extends Component {
       const dropdownCard = getClosest(target, '.dropdown__card');
 
       if (dropdown && dropdownCard) {
-        const { id, category, tag } = dropdownCard.dataset as {
-          id: string;
-          category: CategoryType;
-          tag: string;
-        };
+        const { id, category, tag } = dropdownCard.dataset;
         tagStore.dispach({
           type: actionType.ADD_TAG,
-          tag: { id, category, tag },
+          payload: { id, category, tag },
         });
         this.elementVisibleHandler(input);
       }

--- a/frontend/carbook/src/store/index.ts
+++ b/frontend/carbook/src/store/index.ts
@@ -1,1 +1,29 @@
-export { tagStore } from './tagStore';
+export interface IAction {
+  type: string;
+  payload: {
+    [property: string]: any;
+  };
+}
+
+export type IListener = () => void;
+
+export function createStore(reducer: any) {
+  let state: object = {};
+  let handler: object = {};
+  return {
+    dispach: async (action: IAction) => {
+      state = await reducer(state, action);
+
+      Object.entries(handler).forEach(([_, callback]) => {
+        callback();
+      });
+    },
+    subscribe: (component: object, listener: IListener) => {
+      const componentName = component.constructor.name;
+      handler = { ...handler, [componentName]: listener };
+    },
+    getState: () => {
+      return state;
+    },
+  };
+}

--- a/frontend/carbook/src/store/tagStore.ts
+++ b/frontend/carbook/src/store/tagStore.ts
@@ -1,4 +1,5 @@
 import { CategoryType } from '@/interfaces';
+import { IAction, createStore } from '@/store';
 
 interface ITagObj {
   [id: string]: {
@@ -7,43 +8,13 @@ interface ITagObj {
   };
 }
 
-interface IAction {
-  type: string;
-  tag: {
-    id: string;
-    category?: CategoryType;
-    tag?: string;
-  };
-}
-
-type handler = () => void;
-
 export const actionType = {
   ADD_TAG: 'ADD_TAG',
   DELETE_TAG: 'DELETE_TAG',
 };
 
-function createStore(reducer: any) {
-  let state: ITagObj = {};
-  let handler: Array<handler> = [];
-  return {
-    dispach: async (action: IAction) => {
-      state = await reducer(state, action);
-      handler.forEach((callback) => {
-        callback();
-      });
-    },
-    subscribe: (listener: handler) => {
-      handler.push(listener);
-    },
-    getState: () => {
-      return state;
-    },
-  };
-}
-
 async function reducer(state: ITagObj = {}, action: IAction) {
-  const { id, category, tag } = action.tag;
+  const { id, category, tag } = action.payload;
   switch (action.type) {
     case actionType.ADD_TAG:
       return { ...state, [id]: { category, tag } };


### PR DESCRIPTION
createStore를 모듈로 분리하였습니다

## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #109 

## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->

이전 생성됐던 렌더 함수가 쌓이는 문제를 해결하고, createStore를 모듈화 하였습니다.

store/index.ts 를 보면 createStore 함수가 존재합니다
사용 방법은 관리하고 싶은 데이터가 있을 때 store에 파일을 하나 만든 후
reducer만 정의하여 createStore을 불러와 store을 생성해주면 됩니다.

action은 type과 payload 키값을 가집니다.
type은 액션이름. payload는 필요한  data를 처리할 수 있습니다.

<정리>
1. store에 파일을 만든 후 reducer를 정의, createStore함수를 불러와 store을 생성한다.
2. 컴포넌트의 렌더함수가 해당 store을 구독하고 싶으면 store이름.subscribe(this, this.render.bind(this)) 형태로 작성
+ subscribe는 컴포넌트 이름과 렌더 함수를 전달 해야하는데... 형태가 보기 좋진 않아서
   함수 형태에 대해 좋은 방법이 있다면... 알려주세요

3. 그러면 state변경시 store의 dispatch함수가 실행되면서 구독했던 렌더링 함수들이 실행된다.


## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

X

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

X
