### PR TITLE
feat: 모든 태그 검색 기능 구현

### DIFF
--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/controller/HashtagController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/controller/HashtagController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import softeer.carbook.domain.hashtag.dto.HashtagSearchResponse;
+import softeer.carbook.domain.hashtag.dto.TypeSearchResponse;
 import softeer.carbook.domain.hashtag.service.HashtagService;
 
 @RestController
@@ -25,5 +26,12 @@ public class HashtagController {
     public ResponseEntity<HashtagSearchResponse> searchHashtag(@RequestParam String keyword) {
         HashtagSearchResponse hashtagSearchResponse = hashtagService.searchHashTag(keyword);
         return new ResponseEntity<>(hashtagSearchResponse, HttpStatus.OK);
+    }
+
+    // 차량 종류 태그 검색
+    @GetMapping("/search/type/")
+    public ResponseEntity<TypeSearchResponse> searchType(@RequestParam String keyword) {
+        TypeSearchResponse typeSearchResponse = hashtagService.searchType(keyword);
+        return new ResponseEntity<>(typeSearchResponse, HttpStatus.OK);
     }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/controller/HashtagController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/controller/HashtagController.java
@@ -34,10 +34,10 @@ public class HashtagController {
         return new ResponseEntity<>(hashtagSearchResponse, HttpStatus.OK);
     }
 
-    // 차량 종류 태그 검색
-    @GetMapping("/search/type/")
-    public ResponseEntity<TypeSearchResponse> searchType(@RequestParam String keyword) {
-        TypeSearchResponse typeSearchResponse = hashtagService.searchType(keyword);
-        return new ResponseEntity<>(typeSearchResponse, HttpStatus.OK);
-    }
+//    // 차량 종류 태그 검색
+//    @GetMapping("/search/type/")
+//    public ResponseEntity<TypeSearchResponse> searchType(@RequestParam String keyword) {
+//        TypeSearchResponse typeSearchResponse = hashtagService.searchType(keyword);
+//        return new ResponseEntity<>(typeSearchResponse, HttpStatus.OK);
+//    }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/controller/HashtagController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/controller/HashtagController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import softeer.carbook.domain.hashtag.dto.HashtagSearchResponse;
+import softeer.carbook.domain.hashtag.dto.TagSearchResopnse;
 import softeer.carbook.domain.hashtag.dto.TypeSearchResponse;
 import softeer.carbook.domain.hashtag.service.HashtagService;
 
@@ -20,6 +21,11 @@ public class HashtagController {
     }
 
     // 모든 태그 검색
+    @GetMapping("/search/")
+    public ResponseEntity<TagSearchResopnse> searchAllTags(@RequestParam String keyword) {
+        TagSearchResopnse tagSearchResopnse = hashtagService.searchAllTags(keyword);
+        return new ResponseEntity<>(tagSearchResopnse, HttpStatus.OK);
+    }
 
     // 해시태그 검색
     @GetMapping("/search/hashtag/")

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/dto/Keyword.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/dto/Keyword.java
@@ -1,0 +1,42 @@
+package softeer.carbook.domain.hashtag.dto;
+
+import softeer.carbook.domain.hashtag.model.Hashtag;
+import softeer.carbook.domain.hashtag.model.Model;
+import softeer.carbook.domain.hashtag.model.Type;
+
+public class Keyword {
+    private final int id;
+    private final String category;
+    private final String tag;
+
+    public Keyword(int id, String category, String tag) {
+        this.id = id;
+        this.category = category;
+        this.tag = tag;
+    }
+
+    // Entity -> DTO
+    public static Keyword of(Type type) {
+        return new Keyword(type.getId(), "type", type.getTag());
+    }
+
+    public static Keyword of(Model model) {
+        return new Keyword(model.getId(), "model", model.getTag());
+    }
+
+    public static Keyword of(Hashtag hashtag) {
+        return new Keyword(hashtag.getId(), "hashtag", hashtag.getTag());
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+}

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/dto/TagSearchResopnse.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/dto/TagSearchResopnse.java
@@ -1,0 +1,33 @@
+package softeer.carbook.domain.hashtag.dto;
+
+import java.util.List;
+
+public class TagSearchResopnse {
+    private List<Keyword> keywords;
+
+    public TagSearchResopnse(TagSearchResponseBuilder builder) {
+        this.keywords = builder.keywords;
+    }
+
+    public List<Keyword> getKeywords() {
+        return keywords;
+    }
+
+    public static class TagSearchResponseBuilder {
+
+        private List<Keyword> keywords;
+
+        public TagSearchResponseBuilder() {
+        }
+
+        public TagSearchResponseBuilder keywords(List<Keyword> keywords) {
+            this.keywords = keywords;
+            return this;
+        }
+
+        public TagSearchResopnse build() {
+            return new TagSearchResopnse(this);
+        }
+
+    }
+}

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/dto/TagSearchResopnse.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/dto/TagSearchResopnse.java
@@ -3,24 +3,24 @@ package softeer.carbook.domain.hashtag.dto;
 import java.util.List;
 
 public class TagSearchResopnse {
-    private List<Keyword> keywords;
+    private List<TagSearchResult> keywords;
 
     public TagSearchResopnse(TagSearchResponseBuilder builder) {
         this.keywords = builder.keywords;
     }
 
-    public List<Keyword> getKeywords() {
+    public List<TagSearchResult> getKeywords() {
         return keywords;
     }
 
     public static class TagSearchResponseBuilder {
 
-        private List<Keyword> keywords;
+        private List<TagSearchResult> keywords;
 
         public TagSearchResponseBuilder() {
         }
 
-        public TagSearchResponseBuilder keywords(List<Keyword> keywords) {
+        public TagSearchResponseBuilder keywords(List<TagSearchResult> keywords) {
             this.keywords = keywords;
             return this;
         }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/dto/TagSearchResult.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/dto/TagSearchResult.java
@@ -4,28 +4,28 @@ import softeer.carbook.domain.hashtag.model.Hashtag;
 import softeer.carbook.domain.hashtag.model.Model;
 import softeer.carbook.domain.hashtag.model.Type;
 
-public class Keyword {
+public class TagSearchResult {
     private final int id;
     private final String category;
     private final String tag;
 
-    public Keyword(int id, String category, String tag) {
+    public TagSearchResult(int id, String category, String tag) {
         this.id = id;
         this.category = category;
         this.tag = tag;
     }
 
     // Entity -> DTO
-    public static Keyword of(Type type) {
-        return new Keyword(type.getId(), "type", type.getTag());
+    public static TagSearchResult of(Type type) {
+        return new TagSearchResult(type.getId(), "type", type.getTag());
     }
 
-    public static Keyword of(Model model) {
-        return new Keyword(model.getId(), "model", model.getTag());
+    public static TagSearchResult of(Model model) {
+        return new TagSearchResult(model.getId(), "model", model.getTag());
     }
 
-    public static Keyword of(Hashtag hashtag) {
-        return new Keyword(hashtag.getId(), "hashtag", hashtag.getTag());
+    public static TagSearchResult of(Hashtag hashtag) {
+        return new TagSearchResult(hashtag.getId(), "hashtag", hashtag.getTag());
     }
 
     public int getId() {

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/dto/TypeSearchResponse.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/dto/TypeSearchResponse.java
@@ -1,0 +1,34 @@
+package softeer.carbook.domain.hashtag.dto;
+
+import softeer.carbook.domain.hashtag.model.Type;
+
+import java.util.List;
+
+public class TypeSearchResponse {
+    private List<Type> types;
+
+    public TypeSearchResponse(TypeSearchResponseBuilder builder) {
+        this.types = builder.types;
+    }
+
+    public List<Type> getTypes() {
+        return types;
+    }
+
+    public static class TypeSearchResponseBuilder {
+
+        private List<Type> types;
+
+        public TypeSearchResponseBuilder() {
+        }
+
+        public TypeSearchResponseBuilder types(List<Type> types) {
+            this.types = types;
+            return this;
+        }
+
+        public TypeSearchResponse build() {
+            return new TypeSearchResponse(this);
+        }
+    }
+}

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/model/Model.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/model/Model.java
@@ -1,0 +1,25 @@
+package softeer.carbook.domain.hashtag.model;
+
+public class Model {
+    private final int id;
+    private final int typeId;
+    private final String tag;
+
+    public Model(int id, int typeId, String tag) {
+        this.id = id;
+        this.typeId = typeId;
+        this.tag = tag;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public int getTypeId() {
+        return typeId;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+}

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/model/Type.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/model/Type.java
@@ -1,0 +1,19 @@
+package softeer.carbook.domain.hashtag.model;
+
+public class Type {
+    private final int id;
+    private final String tag;
+
+    public Type(int id, String tag) {
+        this.id = id;
+        this.tag = tag;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+}

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/repository/HashtagRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/repository/HashtagRepository.java
@@ -30,7 +30,7 @@ public class HashtagRepository {
     }
 
     public List<Type> searchTypeByPrefix(String keyword) {
-        return jdbcTemplate.query("SELECT t.id, t.tag FROM Type t WHERE tag LIKE '" + keyword + "%'", typeRowMapper());
+        return jdbcTemplate.query("SELECT t.id, t.tag FROM TYPE t WHERE tag LIKE '" + keyword + "%'", typeRowMapper());
     }
 
     public List<Model> searchModelByPrefix(String keyword) {

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/repository/HashtagRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/repository/HashtagRepository.java
@@ -6,6 +6,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 import softeer.carbook.domain.hashtag.exception.HashtagNotExistException;
 import softeer.carbook.domain.hashtag.model.Hashtag;
+import softeer.carbook.domain.hashtag.model.Model;
 import softeer.carbook.domain.hashtag.model.Type;
 
 import javax.sql.DataSource;
@@ -28,23 +29,35 @@ public class HashtagRepository {
                 .orElseThrow(() -> new HashtagNotExistException());
     }
 
-    public List<Hashtag> searchHashtagByPrefix(String keyword) {
-        return jdbcTemplate.query("SELECT h.id, h.tag FROM HASHTAG h WHERE tag LIKE '" + keyword + "%'", hashtagRowMapper());
-    }
-
     public List<Type> searchTypeByPrefix(String keyword) {
         return jdbcTemplate.query("SELECT t.id, t.tag FROM Type t WHERE tag LIKE '" + keyword + "%'", typeRowMapper());
     }
 
-    private RowMapper<Hashtag> hashtagRowMapper() {
-        return (rs, rowNum) -> new Hashtag(
+    public List<Model> searchModelByPrefix(String keyword) {
+        return jdbcTemplate.query("SELECT m.id, m.type_id, m.tag FROM MODEL m WHERE tag LIKE '" + keyword + "%'", modelRowMapper());
+    }
+
+    public List<Hashtag> searchHashtagByPrefix(String keyword) {
+        return jdbcTemplate.query("SELECT h.id, h.tag FROM HASHTAG h WHERE tag LIKE '" + keyword + "%'", hashtagRowMapper());
+    }
+
+    private RowMapper<Type> typeRowMapper() {
+        return (rs, rowNum) -> new Type(
                 rs.getInt("id"),
                 rs.getString("tag")
         );
     }
 
-    private RowMapper<Type> typeRowMapper() {
-        return (rs, rowNum) -> new Type(
+    private RowMapper<Model> modelRowMapper() {
+        return (rs, rowNum) -> new Model(
+                rs.getInt("id"),
+                rs.getInt("type_id"),
+                rs.getString("tag")
+        );
+    }
+
+    private RowMapper<Hashtag> hashtagRowMapper() {
+        return (rs, rowNum) -> new Hashtag(
                 rs.getInt("id"),
                 rs.getString("tag")
         );

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/repository/HashtagRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/repository/HashtagRepository.java
@@ -6,6 +6,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 import softeer.carbook.domain.hashtag.exception.HashtagNotExistException;
 import softeer.carbook.domain.hashtag.model.Hashtag;
+import softeer.carbook.domain.hashtag.model.Type;
 
 import javax.sql.DataSource;
 import java.util.List;
@@ -21,18 +22,29 @@ public class HashtagRepository {
     }
 
     public Hashtag findHashtagByName(String tag) {
-        List<Hashtag> hashtags = jdbcTemplate.query("SELECT h.id, h.tag FROM HASHTAG h WHERE tag = ?", tagRowMapper(), tag);
+        List<Hashtag> hashtags = jdbcTemplate.query("SELECT h.id, h.tag FROM HASHTAG h WHERE tag = ?", hashtagRowMapper(), tag);
         return hashtags.stream()
                 .findAny()
                 .orElseThrow(() -> new HashtagNotExistException());
     }
 
     public List<Hashtag> searchHashtagByPrefix(String keyword) {
-        return jdbcTemplate.query("SELECT h.id, h.tag FROM HASHTAG h WHERE tag LIKE '" + keyword + "%'", tagRowMapper());
+        return jdbcTemplate.query("SELECT h.id, h.tag FROM HASHTAG h WHERE tag LIKE '" + keyword + "%'", hashtagRowMapper());
     }
 
-    private RowMapper<Hashtag> tagRowMapper() {
+    public List<Type> searchTypeByPrefix(String keyword) {
+        return jdbcTemplate.query("SELECT t.id, t.tag FROM Type t WHERE tag LIKE '" + keyword + "%'", typeRowMapper());
+    }
+
+    private RowMapper<Hashtag> hashtagRowMapper() {
         return (rs, rowNum) -> new Hashtag(
+                rs.getInt("id"),
+                rs.getString("tag")
+        );
+    }
+
+    private RowMapper<Type> typeRowMapper() {
+        return (rs, rowNum) -> new Type(
                 rs.getInt("id"),
                 rs.getString("tag")
         );

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/service/HashtagService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/service/HashtagService.java
@@ -3,7 +3,9 @@ package softeer.carbook.domain.hashtag.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import softeer.carbook.domain.hashtag.dto.HashtagSearchResponse;
+import softeer.carbook.domain.hashtag.dto.TypeSearchResponse;
 import softeer.carbook.domain.hashtag.model.Hashtag;
+import softeer.carbook.domain.hashtag.model.Type;
 import softeer.carbook.domain.hashtag.repository.HashtagRepository;
 
 import java.util.List;
@@ -23,6 +25,14 @@ public class HashtagService {
 
         return new HashtagSearchResponse.HashtagSearchResponseBuilder()
                 .hashtags(hashtags)
+                .build();
+    }
+
+    public TypeSearchResponse searchType(String keyword) {
+        List<Type> types = hashtagRepository.searchTypeByPrefix(keyword);
+
+        return new TypeSearchResponse.TypeSearchResponseBuilder()
+                .types(types)
                 .build();
     }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/service/HashtagService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/service/HashtagService.java
@@ -52,11 +52,11 @@ public class HashtagService {
                 .build();
     }
 
-    public TypeSearchResponse searchType(String keyword) {
-        List<Type> types = hashtagRepository.searchTypeByPrefix(keyword);
-
-        return new TypeSearchResponse.TypeSearchResponseBuilder()
-                .types(types)
-                .build();
-    }
+//    public TypeSearchResponse searchType(String keyword) {
+//        List<Type> types = hashtagRepository.searchTypeByPrefix(keyword);
+//
+//        return new TypeSearchResponse.TypeSearchResponseBuilder()
+//                .types(types)
+//                .build();
+//    }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/service/HashtagService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/service/HashtagService.java
@@ -3,12 +3,16 @@ package softeer.carbook.domain.hashtag.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import softeer.carbook.domain.hashtag.dto.HashtagSearchResponse;
+import softeer.carbook.domain.hashtag.dto.Keyword;
+import softeer.carbook.domain.hashtag.dto.TagSearchResopnse;
 import softeer.carbook.domain.hashtag.dto.TypeSearchResponse;
 import softeer.carbook.domain.hashtag.model.Hashtag;
+import softeer.carbook.domain.hashtag.model.Model;
 import softeer.carbook.domain.hashtag.model.Type;
 import softeer.carbook.domain.hashtag.repository.HashtagRepository;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class HashtagService {
@@ -18,6 +22,26 @@ public class HashtagService {
     @Autowired
     public HashtagService(HashtagRepository hashtagRepository) {
         this.hashtagRepository = hashtagRepository;
+    }
+
+    public TagSearchResopnse searchAllTags(String keyword) {
+        List<Type> types = hashtagRepository.searchTypeByPrefix(keyword);
+        List<Model> models = hashtagRepository.searchModelByPrefix(keyword);
+        List<Hashtag> hashtags = hashtagRepository.searchHashtagByPrefix(keyword);
+
+        List<Keyword> keywords = types.stream()
+                .map(Keyword::of)
+                .collect(Collectors.toList());
+        keywords.addAll(models.stream()
+                .map(Keyword::of)
+                .collect(Collectors.toList()));
+        keywords.addAll(hashtags.stream()
+                .map(Keyword::of)
+                .collect(Collectors.toList()));
+
+        return new TagSearchResopnse.TagSearchResponseBuilder()
+                .keywords(keywords)
+                .build();
     }
 
     public HashtagSearchResponse searchHashTag(String keyword) {

--- a/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/service/HashtagService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/hashtag/service/HashtagService.java
@@ -3,9 +3,8 @@ package softeer.carbook.domain.hashtag.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import softeer.carbook.domain.hashtag.dto.HashtagSearchResponse;
-import softeer.carbook.domain.hashtag.dto.Keyword;
+import softeer.carbook.domain.hashtag.dto.TagSearchResult;
 import softeer.carbook.domain.hashtag.dto.TagSearchResopnse;
-import softeer.carbook.domain.hashtag.dto.TypeSearchResponse;
 import softeer.carbook.domain.hashtag.model.Hashtag;
 import softeer.carbook.domain.hashtag.model.Model;
 import softeer.carbook.domain.hashtag.model.Type;
@@ -29,18 +28,18 @@ public class HashtagService {
         List<Model> models = hashtagRepository.searchModelByPrefix(keyword);
         List<Hashtag> hashtags = hashtagRepository.searchHashtagByPrefix(keyword);
 
-        List<Keyword> keywords = types.stream()
-                .map(Keyword::of)
+        List<TagSearchResult> results = types.stream()
+                .map(TagSearchResult::of)
                 .collect(Collectors.toList());
-        keywords.addAll(models.stream()
-                .map(Keyword::of)
+        results.addAll(models.stream()
+                .map(TagSearchResult::of)
                 .collect(Collectors.toList()));
-        keywords.addAll(hashtags.stream()
-                .map(Keyword::of)
+        results.addAll(hashtags.stream()
+                .map(TagSearchResult::of)
                 .collect(Collectors.toList()));
 
         return new TagSearchResopnse.TagSearchResponseBuilder()
-                .keywords(keywords)
+                .keywords(results)
                 .build();
     }
 


### PR DESCRIPTION
## 📌 이슈번호

- close #141

## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
포스트맨으로 테스트하였습니다.
- 차량 종류(`Type`) 클래스 생성
- 차량 모델(`Model`) 클래스 생성
- `HashtagRepository`
    - 접두어로 차량 종류를 검색하는 `searchTypeByPrefix()` 메서드 구현
    - 접두어로 차량 모델을 검색하는 `searchModelByPrefix()` 메서드 구현
- 모든 태그 검색 시 검색 결과를 저장하는 `TagSearchResult` DTO 객체 생성
- 모든 태그 검색의 응답에 사용할 `TagSearchResponse` DTO 응답 객체 생성
- `HashtagService`
    - 모든 태그를 검색하는 `searchAllTags()` 기능 구현
- `HashtagController`
    - `searchAllTags()`: 쿼리 파라미터로 주어진 키워드로 시작하는 모든 태그를 검색하여 그 결과에 대한 응답을 반환

### API 명세 수정에 따라 주석처리한 부분
- `HashtagController`의 `searchType()`
- `HashtagService`의 `searchType()`

## 📖 구현 스크린샷

## 📖 PR 포인트 & 궁금한 점
`TypeSearchResponse` 응답 객체는 원래 차량 종류 태그 검색의 응답에 사용할 예정이었지만, API 명세 수정에 따라 사용되지 않게 되었습니다. 하지만 차량 종류 전체 조회 API에서 응답 객체로 사용될 수 있으므로 일단 삭제하지 않았습니다.
