### PR TITLE
feat: 프로필 페이지 api 연동

### DIFF
--- a/frontend/carbook/src/components/Profile/FollowLists.ts
+++ b/frontend/carbook/src/components/Profile/FollowLists.ts
@@ -10,11 +10,11 @@ export default class Followlists extends Component {
   }
 
   async receiveFollowLists() {
-    const { profileMode } = this.props;
+    const { profileMode, nickname } = this.props;
 
     const mode = profileMode === "follower" ? "followers" : "followings";
     const data = await basicAPI
-      .get(`/api/profile/${mode}?nickname=dongja1`)
+      .get(`/api/profile/${mode}?nickname=${nickname}`)
       .then((response) => response.data)
       .catch((error) => error);
 

--- a/frontend/carbook/src/components/Profile/FollowLists.ts
+++ b/frontend/carbook/src/components/Profile/FollowLists.ts
@@ -1,10 +1,11 @@
 import { basicAPI } from "@/api";
 import { Component } from "@/core";
-import { IFollows } from "@/interfaces";
+// import { IFollows } from "@/interfaces";
 import { push } from "@/utils/router/navigate";
 
 export default class Followlists extends Component {
   setup(): void {
+    this.setState({ follows: [] });
     this.receiveFollowLists();
   }
 
@@ -32,7 +33,9 @@ export default class Followlists extends Component {
           ${profileMode === "follower" ? "팔로워" : "팔로잉"}
         </h2>
         <ul class = 'profile__contents-followers'>
-        
+        ${this.state.follows
+          .map((nickname: string) => FollowlistsItem(isMyProfile, nickname))
+          .join("")}
         </ul>
         `;
   }

--- a/frontend/carbook/src/components/Profile/FollowLists.ts
+++ b/frontend/carbook/src/components/Profile/FollowLists.ts
@@ -1,20 +1,38 @@
+import { basicAPI } from "@/api";
 import { Component } from "@/core";
 import { IFollows } from "@/interfaces";
 import { push } from "@/utils/router/navigate";
 
 export default class Followlists extends Component {
+  setup(): void {
+    this.receiveFollowLists();
+  }
+
+  async receiveFollowLists() {
+    const { profileMode } = this.props;
+
+    const mode = profileMode === "follower" ? "followers" : "followings";
+    const data = await basicAPI
+      .get(`/api/profile/${mode}?nickname=dongja1`)
+      .then((response) => response.data)
+      .catch((error) => error);
+
+    console.log(data.nicknames);
+
+    this.setState({
+      ...this.state,
+      follows: data.nicknames,
+    });
+  }
+
   template(): string {
-    const { profileMode, isMyProfile, follows } = this.props;
+    const { profileMode, isMyProfile } = this.props;
     return /*html*/ `
         <h2 class = 'profile__contents-header'>
           ${profileMode === "follower" ? "팔로워" : "팔로잉"}
         </h2>
         <ul class = 'profile__contents-followers'>
-          ${follows
-            .map(({ nickname }: IFollows) =>
-              FollowlistsItem(isMyProfile, nickname)
-            )
-            .join("")}
+        
         </ul>
         `;
   }

--- a/frontend/carbook/src/components/Profile/FollowLists.ts
+++ b/frontend/carbook/src/components/Profile/FollowLists.ts
@@ -18,8 +18,6 @@ export default class Followlists extends Component {
       .then((response) => response.data)
       .catch((error) => error);
 
-    console.log(data.nicknames);
-
     this.setState({
       ...this.state,
       follows: data.nicknames,

--- a/frontend/carbook/src/components/Profile/HeaderContents.ts
+++ b/frontend/carbook/src/components/Profile/HeaderContents.ts
@@ -6,15 +6,15 @@ export default class HeaderContents extends Component {
     return /*html*/ `
         <section class ='profile-posts'>
           <div class ='profile-posts-title'>게시물</div>
-          <div class ='profile-posts-count'>${posts}</div>
+          <div class ='profile-posts-count'>${posts ?? ""}</div>
         </section>
         <section class ='profile-follower'>
           <div class ='profile-follower-title'>팔로워</div>
-          <div class ='profile-follower-count'>${follower}</div>
+          <div class ='profile-follower-count'>${follower ?? ""}</div>
         </section>
         <section class ='profile-following'>
           <div class ='profile-following-title'>팔로잉</div>
-          <div class ='profile-following-count'>${following}</div>
+          <div class ='profile-following-count'>${following ?? ""}</div>
         </section>
         `;
   }

--- a/frontend/carbook/src/components/Profile/HeaderInfo.ts
+++ b/frontend/carbook/src/components/Profile/HeaderInfo.ts
@@ -6,10 +6,10 @@ export default class HeaderInfo extends Component {
     const { nickname, email } = this.props;
     return /*html*/ `
       <div class = 'header-info-header'>
-        <div class ='user-nickname'>${nickname}</div>
+        <div class ='user-nickname'>${nickname ?? ""}</div>
         <div class ='modify-status'></div>
       </div>
-      <div class ='user-email'>${email}</div>
+      <div class ='user-email'>${email ?? ""}</div>
       `;
   }
 

--- a/frontend/carbook/src/components/Profile/Menu.ts
+++ b/frontend/carbook/src/components/Profile/Menu.ts
@@ -1,4 +1,6 @@
+import { basicAPI } from "@/api";
 import { Component } from "@/core";
+import { push } from "../../utils/router/navigate";
 
 export default class Menu extends Component {
   template(): string {
@@ -21,13 +23,32 @@ export default class Menu extends Component {
     this.$target.addEventListener("click", (e: Event) => {
       const target = e.target as HTMLElement;
       const li = target.closest("li");
+      const modal = document.body.querySelector(".alert-modal") as HTMLElement;
+
       if (!li) return;
+      if (li.classList.contains("logout")) {
+        this.doLogout(modal);
+        return;
+      }
       document.body.querySelector(".modify-modal")?.classList.toggle("hidden");
       const menu = this.$target.querySelector(
         ".info-menu-items"
       ) as HTMLElement;
       menu.classList.toggle("hidden");
     });
+  }
+
+  async doLogout(modal: HTMLElement) {
+    const LOGOUTDELAY = 2300;
+    await basicAPI
+      .post(`/api/profile/logout`)
+      .then(() => {
+        showErrorModal(modal, "로그아웃에 성공하셨습니다");
+        setTimeout(() => {
+          push("/");
+        }, LOGOUTDELAY);
+      })
+      .catch((error) => error);
   }
   setEvent(): void {
     this.$target.addEventListener("click", (e: Event) => {
@@ -37,4 +58,15 @@ export default class Menu extends Component {
       menu.classList.toggle("hidden");
     });
   }
+}
+
+function showErrorModal(modal: HTMLElement, errorMessage: string): void {
+  if (modal.classList.contains("FadeInAndOut")) return;
+  modal.innerHTML = errorMessage;
+  modal.classList.toggle("blue");
+  modal.classList.toggle("FadeInAndOut");
+  setTimeout(() => {
+    modal.classList.toggle("FadeInAndOut");
+    modal.classList.toggle("blue");
+  }, 2000);
 }

--- a/frontend/carbook/src/pages/Profile/Profile.scss
+++ b/frontend/carbook/src/pages/Profile/Profile.scss
@@ -15,8 +15,8 @@
     visibility: hidden;
     opacity: 0;
   }
-  .gray {
-    background-color: lightgray;
+  .blue {
+    background-color: $main-light-blue;
   }
   .pink {
     background-color: $main-pink;
@@ -220,7 +220,7 @@
 
   .modify-modal {
     position: fixed;
-    top: 5vh;
+    bottom: -5vh;
     background-color: $main-white;
     width: 100vw;
     min-width: 300px;

--- a/frontend/carbook/src/pages/Profile/Profile.ts
+++ b/frontend/carbook/src/pages/Profile/Profile.ts
@@ -14,13 +14,14 @@ export default class ProfilePage extends Component {
   setup(): void {
     //path에서 닉네임 가져오기
     // console.log(location.pathname.split("/").slice(-1)[0]);
-
-    this.fetchProfilePage();
+    const urlnickname = location.pathname.split("/").slice(-1)[0];
+    this.setState({ nickname: urlnickname });
+    this.fetchProfilePage(urlnickname);
   }
 
-  async fetchProfilePage() {
+  async fetchProfilePage(urlnickname: string) {
     const data = await basicAPI
-      .get("/api/profile?nickname=dongja")
+      .get(`/api/profile?nickname=${urlnickname}`)
       .then((response) => response.data)
       .catch((error) => error);
     console.log(data);
@@ -87,6 +88,7 @@ export default class ProfilePage extends Component {
         profileMode: this.state.profileMode,
         isMyProfile: this.state.isMyProfile,
         follows: this.state.followers,
+        nickname: this.state.nickname,
       });
 
     this.state.profileMode === "following" &&
@@ -94,6 +96,7 @@ export default class ProfilePage extends Component {
         profileMode: this.state.profileMode,
         isMyProfile: this.state.isMyProfile,
         follows: this.state.followings,
+        nickname: this.state.nickname,
       });
   }
 
@@ -104,7 +107,7 @@ export default class ProfilePage extends Component {
     modifyInfoButton?.addEventListener("click", (e: Event) => {
       e.preventDefault();
       const modal = document.body.querySelector(".alert-modal") as HTMLElement;
-      modal.classList.add("gray");
+      modal.classList.add("blue");
       showErrorModal(modal, "회원정보가 변경되었습니다");
       setTimeout(() => {
         document.body
@@ -171,7 +174,7 @@ export default class ProfilePage extends Component {
     await basicAPI.post(`/api/profile/follow`, {
       followingNickname: this.state.nickname,
     });
-    this.fetchProfilePage();
+    this.fetchProfilePage(this.state.nickname);
   }
 }
 

--- a/frontend/carbook/src/pages/Profile/Profile.ts
+++ b/frontend/carbook/src/pages/Profile/Profile.ts
@@ -24,7 +24,6 @@ export default class ProfilePage extends Component {
       .get(`/api/profile?nickname=${urlnickname}`)
       .then((response) => response.data)
       .catch((error) => error);
-    console.log(data);
     this.setState({
       isMyProfile: data.myProfile,
       isFollow: data.follow,
@@ -35,7 +34,6 @@ export default class ProfilePage extends Component {
       follower: data.follower,
       following: data.following,
     });
-    console.log("img", this.state.images.length);
   }
 
   async receiveFollower() {}
@@ -152,7 +150,6 @@ export default class ProfilePage extends Component {
       }
 
       if (followerSection) {
-        console.log("clicked follower section");
         this.setState({ ...this.state, profileMode: "follower" });
         return;
       }
@@ -170,7 +167,6 @@ export default class ProfilePage extends Component {
 
   async toggleFollow() {
     this.setState({ ...this.state, isFollow: !this.state.isFollow });
-    console.log(this.state.nickname);
     await basicAPI.post(`/api/profile/follow`, {
       followingNickname: this.state.nickname,
     });

--- a/frontend/carbook/src/pages/Profile/Profile.ts
+++ b/frontend/carbook/src/pages/Profile/Profile.ts
@@ -15,12 +15,12 @@ export default class ProfilePage extends Component {
     //path에서 닉네임 가져오기
     // console.log(location.pathname.split("/").slice(-1)[0]);
 
-    this.initProfilePage();
+    this.fetchProfilePage();
   }
 
-  async initProfilePage() {
+  async fetchProfilePage() {
     const data = await basicAPI
-      .get("/api/profile?nickname=Tea")
+      .get("/api/profile?nickname=dongja")
       .then((response) => response.data)
       .catch((error) => error);
     console.log(data);
@@ -119,6 +119,9 @@ export default class ProfilePage extends Component {
        */
     });
 
+    if (this.$target.classList.contains("once")) return;
+    this.$target.classList.add("once");
+
     this.$target.addEventListener("click", (e: Event) => {
       e.preventDefault();
       const target = e.target as HTMLElement;
@@ -157,9 +160,18 @@ export default class ProfilePage extends Component {
       }
 
       if (followButton) {
-        this.setState({ ...this.state, isFollow: !this.state.isFollow });
+        this.toggleFollow();
       }
     });
+  }
+
+  async toggleFollow() {
+    this.setState({ ...this.state, isFollow: !this.state.isFollow });
+    console.log(this.state.nickname);
+    await basicAPI.post(`/api/profile/follow`, {
+      followingNickname: this.state.nickname,
+    });
+    this.fetchProfilePage();
   }
 }
 

--- a/frontend/carbook/src/pages/Profile/Profile.ts
+++ b/frontend/carbook/src/pages/Profile/Profile.ts
@@ -1,6 +1,5 @@
 import { Component } from "@/core";
 import "./Profile.scss";
-import IMAGEURL from "@/assets/images/car.jpg";
 
 import {
   HeaderInfo,
@@ -9,40 +8,37 @@ import {
   Followlists,
 } from "@/components/Profile";
 
+import { basicAPI } from "@/api";
+
 export default class ProfilePage extends Component {
   setup(): void {
-    this.setState({
-      isMyProfile: true,
-      isFollow: false,
-      nickname: "유저닉네임",
-      email: "useremail@gmail.com",
-      profileMode: "posts",
-      images: [
-        { postId: 1, imageUrl: IMAGEURL },
-        { postId: 2, imageUrl: IMAGEURL },
-        { postId: 3, imageUrl: IMAGEURL },
-        { postId: 4, imageUrl: IMAGEURL },
-        { postId: 5, imageUrl: IMAGEURL },
-        { postId: 6, imageUrl: IMAGEURL },
-        { postId: 7, imageUrl: IMAGEURL },
-        { postId: 8, imageUrl: IMAGEURL },
-      ],
-      posts: 11,
-      follower: 164,
-      following: 272,
-      followers: [
-        { nickname: "1번째팔로워" },
-        { nickname: "2번째팔로워" },
-        { nickname: "3번째팔로워" },
-      ],
-      followings: [
-        { nickname: "1번째팔로잉" },
-        { nickname: "2번째팔로잉" },
-        { nickname: "3번째팔로잉" },
-        { nickname: "4번째팔로잉" },
-      ],
-    });
+    //path에서 닉네임 가져오기
+    // console.log(location.pathname.split("/").slice(-1)[0]);
+
+    this.initProfilePage();
   }
+
+  async initProfilePage() {
+    const data = await basicAPI
+      .get("/api/profile?nickname=Tea")
+      .then((response) => response.data)
+      .catch((error) => error);
+    console.log(data);
+    this.setState({
+      isMyProfile: data.myProfile,
+      isFollow: data.follow,
+      nickname: data.nickname,
+      email: data.email,
+      profileMode: "posts",
+      images: data.images,
+      follower: data.follower,
+      following: data.following,
+    });
+    console.log("img", this.state.images.length);
+  }
+
+  async receiveFollower() {}
+
   template(): string {
     return /*html*/ `
     <div class = 'profile__container'>
@@ -74,7 +70,7 @@ export default class ProfilePage extends Component {
       email: this.state.email,
     });
     new HeaderContents(header_contents, {
-      posts: this.state.images.length,
+      posts: this.state.images?.length,
       follower: this.state.follower,
       following: this.state.following,
     });
@@ -150,6 +146,7 @@ export default class ProfilePage extends Component {
       }
 
       if (followerSection) {
+        console.log("clicked follower section");
         this.setState({ ...this.state, profileMode: "follower" });
         return;
       }

--- a/frontend/carbook/src/pages/Signup/Signup.ts
+++ b/frontend/carbook/src/pages/Signup/Signup.ts
@@ -54,7 +54,7 @@ export default class SignupPage extends Component {
 
       const modal = document.body.querySelector(".alert-modal") as HTMLElement;
 
-      if (isEmpty(id, password, nickname, modal)) return false;
+      if (isEmpty(id, password, nickname, modal)) return;
       sendUserInfo(id, password, nickname, modal);
     });
   }

--- a/frontend/carbook/src/store/userStore.ts
+++ b/frontend/carbook/src/store/userStore.ts
@@ -1,0 +1,23 @@
+import {IAction, createStore} from "@/store"
+
+
+export const actionType = {
+    FOLLOW: 'follow',
+    UNFOLLOW: 'unfollow',
+    DELETE_FOLLOWER:
+  }
+
+async function reducer(state: ITagObj = {}, action: IAction) {
+    const { id, category, tag } = action.payload;
+    switch (action.type) {
+      case actionType.ADD_TAG:
+        return { ...state, [id]: { category, tag } };
+      case actionType.DELETE_TAG:
+        delete state[id];
+        return { ...state };
+      default:
+        throw new Error('올바른 action type이 아닙니다');
+    }
+  }
+
+export const userStore = createStore(reducer);


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #72 
- close #78 
- close #74 

## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
프로필 페이지 기능 대부분 구현했습니다.
본인의 페이지의 팔로워, 팔로잉 리스트에서 삭제하는 기능은 아직 구현하지 못했습니다.
스토어는 아직 사용하지 않았고 설계해야할것 같습니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
### 본인의 프로필
https://user-images.githubusercontent.com/43432783/218399478-12d5ba8e-7eed-4d23-aea6-95ee2b6cb4d5.mp4
### 다른 사람 프로필
https://user-images.githubusercontent.com/43432783/218399552-ffbee6d3-b815-47a1-ba13-657dce9a6645.mp4



## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
