### PR TITLE
fix: 프로필 페이지 닉네임 한글일 때 404페이지로 가는 버그 수정

### DIFF
--- a/frontend/carbook/src/constants/path.ts
+++ b/frontend/carbook/src/constants/path.ts
@@ -5,7 +5,9 @@ import {
   PostPage,
   ProfilePage,
   SignupPage,
-} from "@/pages";
+} from '@/pages';
+
+const dd = decodeURI('한녕');
 
 export const routes = [
   { path: /^\/$/, element: HomePage },
@@ -13,6 +15,6 @@ export const routes = [
   { path: /^\/signup$/, element: SignupPage },
   { path: /^\/post\/[\d]+$/, element: PostDetailPage },
   { path: /^\/post\/[\d]+\/edit$/, element: PostPage },
-  { path: /^\/post\/[a-z]+$/, element: PostPage },
-  { path: /^\/profile\/[\w]+$/, element: ProfilePage },
+  { path: /^\/post\/new$/, element: PostPage },
+  { path: /^\/profile\/.+$/, element: ProfilePage },
 ];


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #193 

## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->

닉네임이 한글일 때 404 페이지로 가는 버그를 수정하였습니다.
프로필 페이지에서는 url에서 닉네임을 가져올 때 decode작업을 해줘야 합니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
X

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
X