### PR TITLE
feat: 좋아요/좋아요취소 기능 추가

### DIFF
--- a/backend/carbook/src/main/java/softeer/carbook/domain/follow/service/FollowService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/follow/service/FollowService.java
@@ -33,6 +33,7 @@ public class FollowService {
         // 팔로우 여부 판단
         if(followId.isPresent()){
             // 언팔로우 진행
+
             followRepository.unFollow(followId.get());
             return new Message("Unfollow Success");
         }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/like/controller/LikeController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/like/controller/LikeController.java
@@ -5,24 +5,44 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import softeer.carbook.domain.like.dto.ModifyLikeInfoForm;
 import softeer.carbook.domain.like.service.LikeService;
+import softeer.carbook.domain.user.model.User;
+import softeer.carbook.domain.user.service.UserService;
 import softeer.carbook.global.dto.Message;
+
+import javax.servlet.http.HttpServletRequest;
 
 @RestController
 public class LikeController {
     private final LikeService likeService;
+    private final UserService userService;
 
     @Autowired
-    public LikeController(LikeService likeService){
+    public LikeController(
+            LikeService likeService,
+            UserService userService
+    ){
         this.likeService = likeService;
+        this.userService = userService;
     }
 
     // 좋아요
     // 좋아요 취소
     @PostMapping("/post/like")
     public ResponseEntity<Message> modifyLikeInfo(
-            @RequestBody
+            @RequestBody ModifyLikeInfoForm modifyLikeInfoForm,
+            HttpServletRequest httpServletRequest
     ){
+        // 일단 로그인 확인 후 로그인한 유저 받아오기
+        User loginUser = userService.findLoginedUser(httpServletRequest);
+
+        // 로그인한 유저 정보와 좋아요/좋아요취소를 할 게시글의 id를 파라미터로 전달
+        Message resultMsg = likeService.modifyLikeInfo(
+                loginUser,
+                httpServletRequest
+        );
+        return Message.make200Response(resultMsg.getMessage());
 
     }
 

--- a/backend/carbook/src/main/java/softeer/carbook/domain/like/controller/LikeController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/like/controller/LikeController.java
@@ -39,8 +39,8 @@ public class LikeController {
 
         // 로그인한 유저 정보와 좋아요/좋아요취소를 할 게시글의 id를 파라미터로 전달
         Message resultMsg = likeService.modifyLikeInfo(
-                loginUser,
-                httpServletRequest
+                loginUser.getId(),
+                modifyLikeInfoForm.getPostId()
         );
         return Message.make200Response(resultMsg.getMessage());
 

--- a/backend/carbook/src/main/java/softeer/carbook/domain/like/controller/LikeController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/like/controller/LikeController.java
@@ -1,7 +1,29 @@
 package softeer.carbook.domain.like.controller;
 
-public class LikeController {
-    // 좋아요
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import softeer.carbook.domain.like.service.LikeService;
+import softeer.carbook.global.dto.Message;
 
+@RestController
+public class LikeController {
+    private final LikeService likeService;
+
+    @Autowired
+    public LikeController(LikeService likeService){
+        this.likeService = likeService;
+    }
+
+    // 좋아요
     // 좋아요 취소
+    @PostMapping("/post/like")
+    public ResponseEntity<Message> modifyLikeInfo(
+            @RequestBody
+    ){
+
+    }
+
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/like/dto/ModifyLikeInfoForm.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/like/dto/ModifyLikeInfoForm.java
@@ -1,0 +1,23 @@
+package softeer.carbook.domain.like.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+public class ModifyLikeInfoForm {
+    @NotBlank
+    private final int postId;
+
+    // json 파싱 문제 때문에 빈 생성자를 생성해 주어야 함..
+
+    public ModifyLikeInfoForm() {
+        postId = 0;
+    }
+
+    public ModifyLikeInfoForm(int postId) {
+        this.postId = postId;
+    }
+
+    public int getPostId() {
+        return postId;
+    }
+}

--- a/backend/carbook/src/main/java/softeer/carbook/domain/like/repository/LikeRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/like/repository/LikeRepository.java
@@ -2,10 +2,12 @@ package softeer.carbook.domain.like.repository;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
 import java.util.Objects;
+import java.util.Optional;
 
 @Repository
 public class LikeRepository {
@@ -20,4 +22,28 @@ public class LikeRepository {
                 Integer.class,
                 postId));
     }
+
+    public Optional<Integer> findLikeByUserIdAndPostId(int userId, int postId) {
+        return jdbcTemplate.query(
+                "select id from POST_LIKE where is_deleted = false and user_id = ? and post_id = ?",
+                idRowMapper(), userId, postId).stream().findAny();
+    }
+
+    public void unLike(int likeId) {
+        jdbcTemplate.update(
+                "update POST_LIKE set is_deleted = true where id = ?", likeId);
+    }
+
+    public void addLike(int userId, int postId) {
+        jdbcTemplate.update(
+        "insert into POST_LIKE(user_id, post_id) values (?, ?) " +
+                "on DUPLICATE KEY update is_deleted = false",
+                userId, postId);
+    }
+
+    private RowMapper<Integer> idRowMapper(){
+        return (rs, rowNum) -> rs.getInt("id");
+    }
+
+
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/like/service/LikeService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/like/service/LikeService.java
@@ -1,14 +1,34 @@
 package softeer.carbook.domain.like.service;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import softeer.carbook.domain.like.repository.LikeRepository;
 import softeer.carbook.domain.user.model.User;
 import softeer.carbook.global.dto.Message;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
 
 @Service
 public class LikeService {
-    public Message modifyLikeInfo(User loginUser, HttpServletRequest httpServletRequest) {
-        return null;
+    private final LikeRepository likeRepository;
+
+    @Autowired
+    public LikeService(LikeRepository likeRepository){
+        this.likeRepository = likeRepository;
+    }
+
+    public Message modifyLikeInfo(int userId, int postId) {
+        Optional<Integer> likeId = likeRepository.findLikeByUserIdAndPostId(userId, postId);
+        // 좋아요 여부 판단
+        if(likeId.isPresent()){
+            // 좋아요 취소 진행
+            likeRepository.unLike(likeId.get());
+            return new Message("UnLike Success");
+        }
+
+        // 팔로우 진행
+        likeRepository.addLike(userId, postId);
+        return new Message("Like Success");
     }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/like/service/LikeService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/like/service/LikeService.java
@@ -1,7 +1,14 @@
 package softeer.carbook.domain.like.service;
 
 import org.springframework.stereotype.Service;
+import softeer.carbook.domain.user.model.User;
+import softeer.carbook.global.dto.Message;
+
+import javax.servlet.http.HttpServletRequest;
 
 @Service
 public class LikeService {
+    public Message modifyLikeInfo(User loginUser, HttpServletRequest httpServletRequest) {
+        return null;
+    }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/like/service/LikeService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/like/service/LikeService.java
@@ -1,4 +1,7 @@
 package softeer.carbook.domain.like.service;
 
+import org.springframework.stereotype.Service;
+
+@Service
 public class LikeService {
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/PostRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/PostRepository.java
@@ -67,11 +67,6 @@ public class PostRepository {
                 post.getUpdateDate(), post.getContent(), post.getModelId(), post.getId());
     }
 
-    public Post findPostById(int postId){
-        return jdbcTemplate.query("select p.id, p.user_id, p.create_date, p.update_date, p.content, p.model_id " +
-                "from POST p where id = ?", postRowMapper(), postId).stream().findAny().get();
-    }
-
     private RowMapper<Post> postRowMapper() {
         return (rs, rowNum) -> new Post(
                 rs.getInt("id"),


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #45 
- close #46 

## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
글 상세 페이지에서 좋아요와 좋아요 취소 기능을 추가했습니다.
먼저 로그인 여부를 판단하고, 좋아요 여부를 판단한 후에, 좋아요 혹은 좋아요 취소 과정을 진행하게 됩니다.
포스트맨을 통해 테스트 완료했습니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
