### PR TITLE
feat: 글 삭제 기능

### DIFF
--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/controller/PostController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/controller/PostController.java
@@ -132,10 +132,20 @@ public class PostController {
 
         // 좋아요           > like 로
         // 좋아요 취소       > like 로
+    // 글 삭제
+    @DeleteMapping("/post/{postId}")
+    public ResponseEntity<Message> deletePost(
+            @PathVariable("postId") int postId,
+            HttpServletRequest httpServletRequest
+    ){
+        // 로그인한 사용자 인가요?
+        User user = userService.findLoginedUser(httpServletRequest);
+        Message resultMsg = postService.deletePost(postId, user);
+        return Message.make200Response(resultMsg.getMessage());
+    }
+
 
     // 글 작성 페이지
-
-
     @PostMapping("/post")
     public ResponseEntity<Message> createPost(@ModelAttribute @Valid NewPostForm newPostForm, HttpServletRequest httpServletRequest){
         User loginUser = userService.findLoginedUser(httpServletRequest);

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/exception/InvalidPostAccessException.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/exception/InvalidPostAccessException.java
@@ -1,0 +1,7 @@
+package softeer.carbook.domain.post.exception;
+
+public class InvalidPostAccessException extends RuntimeException{
+    public InvalidPostAccessException() {
+        super("ERROR: Invalid Access");
+    }
+}

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/exception/PostNotExistException.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/exception/PostNotExistException.java
@@ -1,0 +1,7 @@
+package softeer.carbook.domain.post.exception;
+
+public class PostNotExistException extends RuntimeException{
+    public PostNotExistException() {
+        super("ERROR: Post not exist");
+    }
+}

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
@@ -26,6 +26,7 @@ public class ImageRepository {
     public List<Image> getImagesOfRecentPosts(int size, int index) {
         return jdbcTemplate.query("SELECT img.post_id, img.image_url " +
                         "FROM POST AS p INNER JOIN IMAGE AS img ON p.id = img.post_id " +
+                        "WHERE p.is_deleted = false " +
                         "ORDER BY p.create_date DESC LIMIT ?, ?",
                 imageRowMapper(), index, size);
     }
@@ -34,6 +35,7 @@ public class ImageRepository {
         return jdbcTemplate.query("SELECT img.post_id, img.image_url " +
                 "FROM POST AS p, IMAGE AS img, FOLLOW AS f " +
                         "where f.is_deleted = false " +
+                        "and p.is_deleted = false " +
                         "and f.follower_id = ? " +
                         "and f.following_id = p.user_id " +
                         "and p.id = img.post_id " +
@@ -46,6 +48,7 @@ public class ImageRepository {
                 "select IMAGE.post_id, IMAGE.image_url from POST INNER JOIN IMAGE " +
                         "ON POST.id = IMAGE.post_id " +
                         "WHERE POST.user_id = ? " +
+                        "and POST.is_deleted = false " +
                         "ORDER BY create_date DESC",
                 imageRowMapper(), id);
     }
@@ -54,7 +57,8 @@ public class ImageRepository {
         return jdbcTemplate.query(
                 "select IMAGE.post_id, IMAGE.image_url from USER, POST, IMAGE " +
                         "WHERE USER.id = POST.user_id and POST.id = IMAGE.post_id " +
-                        "and USER.nickname = ?" +
+                        "and USER.nickname = ? " +
+                        "and POST.is_deleted = false " +
                         "ORDER BY create_date DESC",
                 imageRowMapper(), profileUserNickname);
     }
@@ -67,7 +71,9 @@ public class ImageRepository {
                 "INNER JOIN POST_HASHTAG ph ON p.id = ph.post_id " +
                 "INNER JOIN HASHTAG h ON ph.tag_id = h.id "+
                 "INNER JOIN IMAGE img ON p.id = img.post_id " +
-                "WHERE (" + conditionalStatement + ") ORDER BY p.create_date DESC LIMIT ?, ?";
+                "WHERE (" + conditionalStatement + ") " +
+                "and p.is_deleted = false " +
+                "ORDER BY p.create_date DESC LIMIT ?, ?";
 
         return jdbcTemplate.query(query, imageRowMapper(), index, size);
     }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/PostRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/PostRepository.java
@@ -84,6 +84,10 @@ public class PostRepository {
                 post.getUpdateDate(), post.getContent(), post.getModelId(), post.getId());
     }
 
+    public void deletePostById(int postId) {
+        jdbcTemplate.update("update POST set is_deleted = true where id = ?", postId);
+    }
+
     private RowMapper<Post> postRowMapper() {
         return (rs, rowNum) -> new Post(
                 rs.getInt("id"),

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/PostRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/PostRepository.java
@@ -6,6 +6,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
+import softeer.carbook.domain.post.exception.PostNotExistException;
 import softeer.carbook.domain.post.model.Post;
 
 import javax.sql.DataSource;
@@ -46,7 +47,9 @@ public class PostRepository {
                 "SELECT id, user_id, create_date, update_date, content, model_id " +
                         "FROM POST " +
                         "WHERE id = ? AND is_deleted = false", postRowMapper(), postId);
-        return post.stream().findAny().orElseThrow();
+        return post.stream().findAny().orElseThrow(
+                PostNotExistException::new
+        );
     }
 
     public List<Post> searchByType(String type) {

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -241,4 +241,7 @@ public class PostService {
         }
     }
 
+    public Message deletePost(int postId, User user) {
+        return null;
+    }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -248,6 +248,10 @@ public class PostService {
         boolean isMyPost = (post.getUserId() == user.getId());
         // 본인이 작성한 글이 아닌데 삭제하려는 경우 예외처리
         if(!isMyPost) throw new InvalidPostAccessException();
-        return null;
+
+        // 게시글 삭제 진행
+        postRepository.deletePostById(postId);
+
+        return new Message("Post Deleted Successfully");
     }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import softeer.carbook.domain.follow.repository.FollowRepository;
 import softeer.carbook.domain.like.repository.LikeRepository;
 import softeer.carbook.domain.post.dto.*;
+import softeer.carbook.domain.post.exception.InvalidPostAccessException;
 import softeer.carbook.domain.post.model.Image;
 import softeer.carbook.domain.post.model.Post;
 import softeer.carbook.domain.post.repository.ImageRepository;
@@ -242,6 +243,11 @@ public class PostService {
     }
 
     public Message deletePost(int postId, User user) {
+        // 사용자가 작성한 글인지 확인
+        Post post = postRepository.findPostById(postId);
+        boolean isMyPost = (post.getUserId() == user.getId());
+        // 본인이 작성한 글이 아닌데 삭제하려는 경우 예외처리
+        if(!isMyPost) throw new InvalidPostAccessException();
         return null;
     }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/global/dto/Message.java
+++ b/backend/carbook/src/main/java/softeer/carbook/global/dto/Message.java
@@ -24,6 +24,13 @@ public class Message {
         );
     }
 
+    public static ResponseEntity<Message> make401Response(String msg){
+        return new ResponseEntity<>(
+                new Message(msg),
+                HttpStatus.UNAUTHORIZED
+        );
+    }
+
     public String getMessage() {
         return message;
     }

--- a/backend/carbook/src/main/java/softeer/carbook/global/exception/ExceptionController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/global/exception/ExceptionController.java
@@ -7,6 +7,7 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import softeer.carbook.domain.post.exception.PostNotExistException;
 import softeer.carbook.global.dto.Message;
 import softeer.carbook.domain.user.exception.*;
 
@@ -63,6 +64,13 @@ public class ExceptionController {
     public ResponseEntity<Message> notLoginStatementException(NotLoginStatementException notLoginE){
         logger.debug(notLoginE.getMessage());
         return Message.make400Response(notLoginE.getMessage());
+    }
+
+    // 해당 게시글이 없을 경우 처리
+    @ExceptionHandler(PostNotExistException.class)
+    public ResponseEntity<Message> postNotExistException(PostNotExistException postNEE){
+        logger.debug(postNEE.getMessage());
+        return Message.make400Response(postNEE.getMessage());
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/backend/carbook/src/main/java/softeer/carbook/global/exception/ExceptionController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/global/exception/ExceptionController.java
@@ -7,6 +7,7 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import softeer.carbook.domain.post.exception.InvalidPostAccessException;
 import softeer.carbook.domain.post.exception.PostNotExistException;
 import softeer.carbook.global.dto.Message;
 import softeer.carbook.domain.user.exception.*;
@@ -63,7 +64,7 @@ public class ExceptionController {
     @ExceptionHandler(NotLoginStatementException.class)
     public ResponseEntity<Message> notLoginStatementException(NotLoginStatementException notLoginE){
         logger.debug(notLoginE.getMessage());
-        return Message.make400Response(notLoginE.getMessage());
+        return Message.make401Response(notLoginE.getMessage());
     }
 
     // 해당 게시글이 없을 경우 처리
@@ -71,6 +72,13 @@ public class ExceptionController {
     public ResponseEntity<Message> postNotExistException(PostNotExistException postNEE){
         logger.debug(postNEE.getMessage());
         return Message.make400Response(postNEE.getMessage());
+    }
+
+    // 남이 게시글 삭제하려고 시도하는 경우
+    @ExceptionHandler(InvalidPostAccessException.class)
+    public ResponseEntity<Message> invalidPostAccessException(InvalidPostAccessException invalidPostAE){
+        logger.debug(invalidPostAE.getMessage());
+        return Message.make401Response(invalidPostAE.getMessage());
     }
 
     @ExceptionHandler(IllegalArgumentException.class)


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #198 

## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
글 삭제 기능을 구현하였습니다.
먼저 로그인한 사용자인지 체크하고, 로그인한 사용자이며, 해당 글을 작성했는지 확인하게 됩니다. 해당 글을 작성하지 않은 사용자가 글을 삭제하려고 접근하는 경우 401 응답을 돌려주게 구현했습니다. 삭제는 소프트 딜리트로 구현해서 post 테이블에 is_deleted를 추가해서 true로 변경하는 로직으로 구현했습니다.
포스트맨을 통해 테스트 완료했습니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
