### PR TITLE
fix: 검색어로 쿼리문에 사용되는 특수문자가 사용되는 경우를 처리하기 위해 쿼리문 수정

### DIFF
--- a/backend/carbook/src/main/java/softeer/carbook/domain/tag/repository/TagRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/tag/repository/TagRepository.java
@@ -6,7 +6,6 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
-import softeer.carbook.domain.tag.dto.TagSearchResult;
 import softeer.carbook.domain.tag.exception.HashtagNotExistException;
 import softeer.carbook.domain.tag.model.Hashtag;
 import softeer.carbook.domain.tag.model.Model;
@@ -16,7 +15,6 @@ import javax.sql.DataSource;
 import java.sql.PreparedStatement;
 import java.sql.Statement;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Repository
 public class TagRepository {
@@ -59,15 +57,15 @@ public class TagRepository {
     }
 
     public List<Type> searchTypeByPrefix(String keyword) {
-        return jdbcTemplate.query("SELECT t.id, t.tag FROM TYPE t WHERE tag LIKE '" + keyword + "%'", typeRowMapper());
+        return jdbcTemplate.query("SELECT t.id, t.tag FROM TYPE t WHERE tag LIKE '[" + keyword + "]%'", typeRowMapper());
     }
 
     public List<Model> searchModelByPrefix(String keyword) {
-        return jdbcTemplate.query("SELECT m.id, m.type_id, m.tag FROM MODEL m WHERE tag LIKE '" + keyword + "%'", modelRowMapper());
+        return jdbcTemplate.query("SELECT m.id, m.type_id, m.tag FROM MODEL m WHERE tag LIKE '[" + keyword + "]%'", modelRowMapper());
     }
 
     public List<Hashtag> searchHashtagByPrefix(String keyword) {
-        return jdbcTemplate.query("SELECT h.id, h.tag FROM HASHTAG h WHERE tag LIKE '" + keyword + "%'", hashtagRowMapper());
+        return jdbcTemplate.query("SELECT h.id, h.tag FROM HASHTAG h WHERE tag LIKE '[" + keyword + "]%'", hashtagRowMapper());
     }
 
     public List<Type> findAllTypes() {
@@ -126,7 +124,7 @@ public class TagRepository {
     }
 
     private RowMapper<String> hashtagStringRowMapper(){
-        return ((rs, rowNum) -> new String(rs.getString("tag")));
+        return ((rs, rowNum) -> rs.getString("tag"));
     }
 
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/tag/service/TagService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/tag/service/TagService.java
@@ -1,5 +1,7 @@
 package softeer.carbook.domain.tag.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import softeer.carbook.domain.tag.dto.*;
@@ -14,6 +16,8 @@ import java.util.stream.Collectors;
 @Service
 public class TagService {
 
+    private static final Logger logger = LoggerFactory.getLogger(TagService.class);
+
     private final TagRepository tagRepository;
 
     @Autowired
@@ -22,11 +26,11 @@ public class TagService {
     }
 
     public TagSearchResopnse searchAllTags(String keyword) {
+        logger.debug("keyword: {}",keyword);
         List<Type> types = tagRepository.searchTypeByPrefix(keyword);
         List<Model> models = tagRepository.searchModelByPrefix(keyword);
         List<Hashtag> hashtags = tagRepository.searchHashtagByPrefix(keyword);
 
-        // todo refactor
         List<TagSearchResult> results = types.stream()
                 .map(TagSearchResult::of)
                 .collect(Collectors.toList());
@@ -41,6 +45,7 @@ public class TagService {
     }
 
     public HashtagSearchResponse searchHashTag(String keyword) {
+        logger.debug("keyword: {}",keyword);
         List<Hashtag> hashtags = tagRepository.searchHashtagByPrefix(keyword);
 
         return new HashtagSearchResponse(hashtags);

--- a/backend/carbook/src/test/java/softeer/carbook/domain/tag/service/TagServiceTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/tag/service/TagServiceTest.java
@@ -3,8 +3,6 @@ package softeer.carbook.domain.tag.service;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -36,7 +34,7 @@ class TagServiceTest {
     ));
 
     @Test
-    @DisplayName("모든 태그 검색 기능 테스트")
+    @DisplayName("모든 태그 검색 기능 테스트 - 검색 결과가 있는 경우")
     void searchAllTags() {
         // given
         String keyword = "keyword";
@@ -60,11 +58,30 @@ class TagServiceTest {
         verify(tagRepository).searchHashtagByPrefix(keyword);
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"맑", "맑음"})
-    @DisplayName("해시태그 검색 기능 테스트")
-    void searchHashTag(String keyword) {
+    @Test
+    @DisplayName("모든 태그 검색 기능 테스트 - 검색 결과가 없는 경우")
+    void searchAllTagsWithNoResult() {
         // given
+        String keyword = "keyword";
+        given(tagRepository.searchTypeByPrefix(keyword)).willReturn(new ArrayList<>());
+        given(tagRepository.searchModelByPrefix(keyword)).willReturn(new ArrayList<>());
+        given(tagRepository.searchHashtagByPrefix(keyword)).willReturn(new ArrayList<>());
+
+        // when
+        TagSearchResopnse response = tagService.searchAllTags(keyword);
+
+        // then
+        assertThat(response.getKeywords()).usingRecursiveComparison().isEqualTo(new ArrayList<>());
+        verify(tagRepository).searchTypeByPrefix(keyword);
+        verify(tagRepository).searchModelByPrefix(keyword);
+        verify(tagRepository).searchHashtagByPrefix(keyword);
+    }
+
+    @Test
+    @DisplayName("해시태그 검색 기능 테스트 - 검색 결과가 있는 경우")
+    void searchHashTag() {
+        // given
+        String keyword = "keyword";
         given(tagRepository.searchHashtagByPrefix(keyword)).willReturn(new ArrayList<>(List.of(
                 new Hashtag(1, "맑음")
         )));
@@ -77,6 +94,22 @@ class TagServiceTest {
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getId()).isEqualTo(1);
         assertThat(result.get(0).getTag()).isEqualTo("맑음");
+        verify(tagRepository).searchHashtagByPrefix(keyword);
+    }
+
+    @Test
+    @DisplayName("해시태그 검색 기능 테스트 - 검색 결과가 없는 경우")
+    void searchHashTagWithNoResult() {
+        // given
+        String keyword = "keyword";
+        given(tagRepository.searchHashtagByPrefix(keyword)).willReturn(new ArrayList<>());
+
+        // when
+        HashtagSearchResponse response = tagService.searchHashTag(keyword);
+
+        // then
+        List<Hashtag> result = response.getHashtags();
+        assertThat(result.size()).isEqualTo(0);
         verify(tagRepository).searchHashtagByPrefix(keyword);
     }
 


### PR DESCRIPTION
## 📌 이슈번호

## 📗 요구 사항과 구현 내용 
'%'가 검색어로 들어올 경우 모든 데이터가 출력되므로, 이를 실제 문자로 인식시키기 위해 쿼리문을 수정하였습니다.
- TagRepository의 쿼리문 수정
- TagService에 로그 출력을 위한 logger 선언 및 사용
- TagServiceTest 테스트 메서드 추가 - searchAllTagsWithNoResult(): 모든 태그 검색 기능 테스트 - 검색 결과가 없는 경우 - searchHashTagWithNoResult(): 해시태그 검색 기능 테스트 - 검색 결과가 없는 경우

## 📖 구현 스크린샷

## 📖 PR 포인트 & 궁금한 점