### PR TITLE
fix: 검색어로 SQL 쿼리문의 특수 문자가 사용되는 경우를 처리하기 위해 쿼리문 2차 수정

### DIFF
--- a/backend/carbook/src/main/java/softeer/carbook/domain/tag/repository/TagRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/tag/repository/TagRepository.java
@@ -80,8 +80,10 @@ public class TagRepository {
         return jdbcTemplate.query("SELECT m.id, m.type_id, m.tag FROM MODEL m WHERE m.tag = ?", modelRowMapper(), tag).get(0);
     }
 
-    public String convertWildCharToRealChar(String keyword) {
-        return keyword.replaceAll("%", "[%]").replaceAll("_", "[_]");
+    public String convertWildCharToRealChar(String oldStr) {
+        String newStr = oldStr.replaceAll("%", "[%]");
+        newStr = newStr.replaceAll("_", "[_]");
+        return newStr;
     }
 
     public int addHashtag(Hashtag hashtag){

--- a/backend/carbook/src/main/java/softeer/carbook/domain/tag/repository/TagRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/tag/repository/TagRepository.java
@@ -30,7 +30,7 @@ public class TagRepository {
         List<Hashtag> hashtags = jdbcTemplate.query("SELECT h.id, h.tag FROM HASHTAG h WHERE tag = ?", hashtagRowMapper(), tag);
         return hashtags.stream()
                 .findAny()
-                .orElseThrow(() -> new HashtagNotExistException());
+                .orElseThrow(HashtagNotExistException::new);
     }
 
     public List<Type> findTypeById(int id) {
@@ -57,15 +57,15 @@ public class TagRepository {
     }
 
     public List<Type> searchTypeByPrefix(String keyword) {
-        return jdbcTemplate.query("SELECT t.id, t.tag FROM TYPE t WHERE tag LIKE '[" + keyword + "]%'", typeRowMapper());
+        return jdbcTemplate.query("SELECT t.id, t.tag FROM TYPE t WHERE tag LIKE '" + convertWildCharToRealChar(keyword) + "%'", typeRowMapper());
     }
 
     public List<Model> searchModelByPrefix(String keyword) {
-        return jdbcTemplate.query("SELECT m.id, m.type_id, m.tag FROM MODEL m WHERE tag LIKE '[" + keyword + "]%'", modelRowMapper());
+        return jdbcTemplate.query("SELECT m.id, m.type_id, m.tag FROM MODEL m WHERE tag LIKE '" + convertWildCharToRealChar(keyword) + "%'", modelRowMapper());
     }
 
     public List<Hashtag> searchHashtagByPrefix(String keyword) {
-        return jdbcTemplate.query("SELECT h.id, h.tag FROM HASHTAG h WHERE tag LIKE '[" + keyword + "]%'", hashtagRowMapper());
+        return jdbcTemplate.query("SELECT h.id, h.tag FROM HASHTAG h WHERE tag LIKE '" + convertWildCharToRealChar(keyword) + "%'", hashtagRowMapper());
     }
 
     public List<Type> findAllTypes() {
@@ -78,6 +78,10 @@ public class TagRepository {
 
     public Model findModelByName(String tag){
         return jdbcTemplate.query("SELECT m.id, m.type_id, m.tag FROM MODEL m WHERE m.tag = ?", modelRowMapper(), tag).get(0);
+    }
+
+    public String convertWildCharToRealChar(String keyword) {
+        return keyword.replaceAll("%", "[%]").replaceAll("_", "[_]");
     }
 
     public int addHashtag(Hashtag hashtag){


### PR DESCRIPTION
## 📌 이슈번호

- close #233

## 📗 요구 사항과 구현 내용
LIKE 절의 와일드 문자는 '%'와 '_'이므로 이 두 문자가 검색어로 들어올 경우를 처리하기 위해 쿼리문을 수정하였습니다. 와일드 문자를 실제 문자로 인식하기 위해서는 검색어 전체가 아니라 와일드 문자가 들어가는 부분만 '[]'로 감싸야하기 때문에 `convertWildCharToRealChar()`을 사용하여 와일드 문자가 실제 문자로 인식되도록 쿼리문을 수정하였습니다.

- `TagRepository`의 쿼리문 수정
- `convertWildCharToRealChar()`: LIKE 절의 와일드 문자 '%'와 '_'가 쿼리문에서 실제 문자로 인식되도록, 파라미터로 들어온 문자열을 수정하여 반환

## 📖 구현 스크린샷

## 📖 PR 포인트 & 궁금한 점
