### PR TITLE
fix: TagRepository의 태그 검색 기능에 쓰이는 모든 쿼리문 수정 및 TagRepository 테스트 코드 작성

### DIFF
--- a/backend/carbook/src/main/java/softeer/carbook/domain/tag/repository/TagRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/tag/repository/TagRepository.java
@@ -57,15 +57,15 @@ public class TagRepository {
     }
 
     public List<Type> searchTypeByPrefix(String keyword) {
-        return jdbcTemplate.query("SELECT t.id, t.tag FROM TYPE t WHERE tag LIKE '" + convertWildCharToRealChar(keyword) + "%'", typeRowMapper());
+        return jdbcTemplate.query("SELECT t.id, t.tag FROM TYPE t WHERE tag LIKE '" + convertWildCharToRealChar(keyword), typeRowMapper());
     }
 
     public List<Model> searchModelByPrefix(String keyword) {
-        return jdbcTemplate.query("SELECT m.id, m.type_id, m.tag FROM MODEL m WHERE tag LIKE '" + convertWildCharToRealChar(keyword) + "%'", modelRowMapper());
+        return jdbcTemplate.query("SELECT m.id, m.type_id, m.tag FROM MODEL m WHERE tag LIKE '" + convertWildCharToRealChar(keyword), modelRowMapper());
     }
 
     public List<Hashtag> searchHashtagByPrefix(String keyword) {
-        return jdbcTemplate.query("SELECT h.id, h.tag FROM HASHTAG h WHERE tag LIKE '" + convertWildCharToRealChar(keyword) + "%'", hashtagRowMapper());
+        return jdbcTemplate.query("SELECT h.id, h.tag FROM HASHTAG h WHERE tag LIKE '" + convertWildCharToRealChar(keyword), hashtagRowMapper());
     }
 
     public List<Type> findAllTypes() {
@@ -81,8 +81,9 @@ public class TagRepository {
     }
 
     public String convertWildCharToRealChar(String oldStr) {
-        String newStr = oldStr.replaceAll("%", "[%]");
-        newStr = newStr.replaceAll("_", "[_]");
+        String newStr = oldStr.replaceAll("%", "!%");
+        newStr = newStr.replaceAll("_", "!_");
+        newStr += "%' ESCAPE '!'";
         return newStr;
     }
 

--- a/backend/carbook/src/test/java/softeer/carbook/domain/tag/repository/TagRepositoryTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/tag/repository/TagRepositoryTest.java
@@ -85,4 +85,32 @@ class TagRepositoryTest {
         assertThat(result.get(0).getId()).isEqualTo(hashtagId);
         assertThat(result.get(0).getTag()).isEqualTo(tagName);
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"%", "%%"})
+    @DisplayName("'%'문자를 접두어로 하여 해시태그를 조회")
+    void searchHashtagByPrefixWithWildCharPercentage(String keyword) {
+        String tagName = "%%%길동";
+        Hashtag hashtag = new Hashtag(tagName);
+        int hashtagId = tagRepository.addHashtag(hashtag);
+
+        List<Hashtag> result = tagRepository.searchHashtagByPrefix(keyword);
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get(0).getId()).isEqualTo(hashtagId);
+        assertThat(result.get(0).getTag()).isEqualTo(tagName);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"_", "__"})
+    @DisplayName("'_'를 접두어로 하여 해시태그를 조회")
+    void searchHashtagByPrefixWithWildCharUnderBar(String keyword) {
+        String tagName = "___길동";
+        Hashtag hashtag = new Hashtag(tagName);
+        int hashtagId = tagRepository.addHashtag(hashtag);
+
+        List<Hashtag> result = tagRepository.searchHashtagByPrefix(keyword);
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get(0).getId()).isEqualTo(hashtagId);
+        assertThat(result.get(0).getTag()).isEqualTo(tagName);
+    }
 }

--- a/backend/carbook/src/test/java/softeer/carbook/domain/tag/repository/TagRepositoryTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/tag/repository/TagRepositoryTest.java
@@ -1,0 +1,88 @@
+package softeer.carbook.domain.tag.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.jdbc.Sql;
+import softeer.carbook.domain.tag.exception.HashtagNotExistException;
+import softeer.carbook.domain.tag.model.Hashtag;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@JdbcTest
+@Sql("classpath:create_table.sql")
+class TagRepositoryTest {
+
+    private TagRepository tagRepository;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @BeforeEach
+    void setUp() {
+        tagRepository = new TagRepository(dataSource);
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+        jdbcTemplate.update("delete from HASHTAG");
+    }
+
+    @Test
+    @DisplayName("태그 이름으로 해시태그 조회")
+    void findHashtagByName() {
+        String tagName = "맑음";
+        Hashtag hashtag = new Hashtag(tagName);
+        int hashtagId = tagRepository.addHashtag(hashtag);
+
+        Hashtag result = tagRepository.findHashtagByName(tagName);
+
+        assertThat(result.getId()).isEqualTo(hashtagId);
+        assertThat(result.getTag()).isEqualTo(tagName);
+    }
+
+    @Test
+    @DisplayName("태그 이름으로 해시태그 조회 - 조회 결과가 없는 경우")
+    void findHashtagByNameWithNoHashtag() {
+        String tagName = "맑음";
+
+        Throwable exception = assertThrows(HashtagNotExistException.class, () -> tagRepository.findHashtagByName(tagName));
+
+        assertThat(exception.getMessage()).isEqualTo("ERROR: Hashtag not exist");
+    }
+
+//    @Test
+//    void findHashtagsByPostId() {
+//        Post post = new Post(1, "content", 1);
+//        int postId = postRepository.addPost(post);
+//
+//        String tagName = "맑음";
+//        Hashtag hashtag = new Hashtag(tagName);
+//        int hashtagId = tagRepository.addHashtag(hashtag);
+//
+//        tagRepository.addPostHashtag(postId, hashtagId);
+//
+//        List<String> result = tagRepository.findHashtagsByPostId(postId);
+//        assertThat(result.get(0)).isEqualTo(tagName);
+//    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"맑", "맑음"})
+    @DisplayName("키워드를 접두어로 하여 해시태그를 조회")
+    void searchHashtagByPrefix(String keyword) {
+        String tagName = "맑음";
+        Hashtag hashtag = new Hashtag(tagName);
+        int hashtagId = tagRepository.addHashtag(hashtag);
+
+        List<Hashtag> result = tagRepository.searchHashtagByPrefix(keyword);
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get(0).getId()).isEqualTo(hashtagId);
+        assertThat(result.get(0).getTag()).isEqualTo(tagName);
+    }
+}


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- #233

## 📗 요구 사항과 구현 내용
`TagRepository` 테스트 코드를 작성하던 중, SQL 쿼리의 LIKE 조건절에 쓰이는 와일드 문자가 검색어에 포함될 경우 제대로 조회가 되지 않는 오류를 발견하여, `TagRepository`의 쿼리문의 LIKE 조건절에서 ESCAPE 옵션을 사용하도록 수정하였습니다.
그리고 `TagRepository` 테스트 코드를 작성하였습니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
