### PR TITLE
test: TagRepositoryTest 테스트 코드 작성 및 리팩토링

### DIFF
--- a/backend/carbook/src/main/java/softeer/carbook/domain/tag/repository/TagRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/tag/repository/TagRepository.java
@@ -26,6 +26,13 @@ public class TagRepository {
         this.jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
+    public Hashtag findHashtagById(int id) {
+        List<Hashtag> hashtags = jdbcTemplate.query("SELECT h.id, h.tag FROM HASHTAG h WHERE id = ?", hashtagRowMapper(), id);
+        return hashtags.stream()
+                .findAny()
+                .orElseThrow(HashtagNotExistException::new);
+    }
+
     public Hashtag findHashtagByName(String tag) {
         List<Hashtag> hashtags = jdbcTemplate.query("SELECT h.id, h.tag FROM HASHTAG h WHERE tag = ?", hashtagRowMapper(), tag);
         return hashtags.stream()

--- a/backend/carbook/src/test/java/softeer/carbook/domain/tag/repository/TagRepositoryTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/tag/repository/TagRepositoryTest.java
@@ -39,7 +39,7 @@ class TagRepositoryTest {
 
     @ParameterizedTest
     @CsvSource(value = {"1,테스트태그1", "2,테스트태그2", "3,테스트태그3"})
-    @DisplayName("태그 이름으로 해시태그 조회")
+    @DisplayName("태그 이름으로 해시태그 조회 테스트")
     void findHashtagByName(int hashtagId, String tagName) {
         // given & when
         Hashtag result = tagRepository.findHashtagByName(tagName);
@@ -51,7 +51,7 @@ class TagRepositoryTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"맑음", "흐림"})
-    @DisplayName("태그 이름으로 해시태그 조회 - 조회 결과가 없는 경우")
+    @DisplayName("태그 이름으로 해시태그 조회 테스트 - 조회 결과가 없는 경우")
     void findHashtagByNameWithNoHashtag(String tagName) {
         // given & when
         Throwable exception = assertThrows(HashtagNotExistException.class, () -> tagRepository.findHashtagByName(tagName));
@@ -61,7 +61,7 @@ class TagRepositoryTest {
     }
 
     @Test
-    @DisplayName("게시물 id로 해시태그 조회")
+    @DisplayName("게시물 id로 해시태그 조회 테스트")
     void findHashtagsByPostId() {
         // given
         int postId = 1;
@@ -78,7 +78,7 @@ class TagRepositoryTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"맑", "맑음"})
-    @DisplayName("키워드를 접두어로 하여 해시태그를 조회")
+    @DisplayName("키워드를 접두어로 한 해시태그 조회 테스트")
     void searchHashtagByPrefix(String keyword) {
         // given
         String tagName = "맑음";
@@ -96,7 +96,7 @@ class TagRepositoryTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"%", "%%"})
-    @DisplayName("'%'문자를 접두어로 하여 해시태그를 조회")
+    @DisplayName("'%'문자를 접두어로 한 해시태그 조회 테스트")
     void searchHashtagByPrefixWithWildCharPercentage(String keyword) {
         // given
         String tagName = "%%%길동";
@@ -114,7 +114,7 @@ class TagRepositoryTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"_", "__"})
-    @DisplayName("'_'를 접두어로 하여 해시태그를 조회")
+    @DisplayName("'_'를 접두어로 한 해시태그 조회 테스트")
     void searchHashtagByPrefixWithWildCharUnderBar(String keyword) {
         // given
         String tagName = "___길동";
@@ -132,7 +132,7 @@ class TagRepositoryTest {
 
     @ParameterizedTest
     @CsvSource(value = {"1,1,아이오닉 6", "2,1,아이오닉 5", "3,1,넥쏘"})
-    @DisplayName("모델 이름으로 모델 태그 조회")
+    @DisplayName("모델 이름으로 모델 태그 조회 테스트")
     void findModelByName(int modelId, int typeId, String tagName) {
         // given & when
         Model result = tagRepository.findModelByName(tagName);

--- a/backend/carbook/src/test/java/softeer/carbook/domain/tag/repository/TagRepositoryTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/tag/repository/TagRepositoryTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.test.context.jdbc.Sql;
-import softeer.carbook.domain.post.repository.PostRepository;
 import softeer.carbook.domain.tag.exception.HashtagNotExistException;
 import softeer.carbook.domain.tag.model.Hashtag;
 import softeer.carbook.domain.tag.model.Model;
@@ -26,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class TagRepositoryTest {
 
     private TagRepository tagRepository;
-    private PostRepository postRepository;
 
     @Autowired
     private DataSource dataSource;
@@ -34,7 +32,6 @@ class TagRepositoryTest {
     @BeforeEach
     void setUp() {
         tagRepository = new TagRepository(dataSource);
-        postRepository = new PostRepository(dataSource);
     }
 
     @ParameterizedTest

--- a/backend/carbook/src/test/java/softeer/carbook/domain/tag/repository/TagRepositoryTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/tag/repository/TagRepositoryTest.java
@@ -58,6 +58,22 @@ class TagRepositoryTest {
     }
 
     @Test
+    @DisplayName("해시태그 추가 테스트")
+    void addHashtag() {
+        // given
+        String tagName = "맑음";
+        Hashtag hashtag = new Hashtag(tagName);
+
+        // when
+        int hashtagId = tagRepository.addHashtag(hashtag);
+
+        // then
+        Hashtag result = tagRepository.findHashtagById(hashtagId);
+        assertThat(result.getId()).isEqualTo(hashtagId);
+        assertThat(result.getTag()).isEqualTo(tagName);
+    }
+
+    @Test
     @DisplayName("게시물 id로 해시태그 조회 테스트")
     void findHashtagsByPostId() {
         // given
@@ -138,5 +154,36 @@ class TagRepositoryTest {
         assertThat(result.getId()).isEqualTo(modelId);
         assertThat(result.getTypeId()).isEqualTo(typeId);
         assertThat(result.getTag()).isEqualTo(tagName);
+    }
+
+    @Test
+    @DisplayName("게시물에 해시태그 추가 테스트")
+    void addPostHashtag() {
+        // given
+        int postId = 2;
+        Hashtag hashtag = tagRepository.findHashtagByName("테스트태그1");
+
+        // when
+        tagRepository.addPostHashtag(postId, hashtag.getId());
+
+        // then
+        List<String> result = tagRepository.findHashtagsByPostId(postId);
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result.get(0)).isEqualTo("테스트태그2");
+        assertThat(result.get(1)).isEqualTo("테스트태그1");
+    }
+
+    @Test
+    @DisplayName("게시물에 해시태그 삭제 테스트")
+    void deletePostHashtag() {
+        // given
+        int postId = 2;
+
+        // when
+        tagRepository.deletePostHashtags(postId);
+
+        // then
+        List<String> result = tagRepository.findHashtagsByPostId(postId);
+        assertThat(result.size()).isEqualTo(0);
     }
 }

--- a/backend/carbook/src/test/java/softeer/carbook/domain/tag/repository/TagRepositoryTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/tag/repository/TagRepositoryTest.java
@@ -4,13 +4,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.jdbc.Sql;
+import softeer.carbook.domain.post.repository.PostRepository;
 import softeer.carbook.domain.tag.exception.HashtagNotExistException;
 import softeer.carbook.domain.tag.model.Hashtag;
+import softeer.carbook.domain.tag.model.Model;
 
 import javax.sql.DataSource;
 import java.util.List;
@@ -20,9 +22,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @JdbcTest
 @Sql("classpath:create_table.sql")
+@Sql("classpath:create_data.sql")
 class TagRepositoryTest {
 
     private TagRepository tagRepository;
+    private PostRepository postRepository;
 
     @Autowired
     private DataSource dataSource;
@@ -30,57 +34,61 @@ class TagRepositoryTest {
     @BeforeEach
     void setUp() {
         tagRepository = new TagRepository(dataSource);
-        JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-        jdbcTemplate.update("delete from HASHTAG");
+        postRepository = new PostRepository(dataSource);
     }
 
-    @Test
+    @ParameterizedTest
+    @CsvSource(value = {"1,테스트태그1", "2,테스트태그2", "3,테스트태그3"})
     @DisplayName("태그 이름으로 해시태그 조회")
-    void findHashtagByName() {
-        String tagName = "맑음";
-        Hashtag hashtag = new Hashtag(tagName);
-        int hashtagId = tagRepository.addHashtag(hashtag);
-
+    void findHashtagByName(int hashtagId, String tagName) {
+        // given & when
         Hashtag result = tagRepository.findHashtagByName(tagName);
 
+        // then
         assertThat(result.getId()).isEqualTo(hashtagId);
         assertThat(result.getTag()).isEqualTo(tagName);
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = {"맑음", "흐림"})
     @DisplayName("태그 이름으로 해시태그 조회 - 조회 결과가 없는 경우")
-    void findHashtagByNameWithNoHashtag() {
-        String tagName = "맑음";
-
+    void findHashtagByNameWithNoHashtag(String tagName) {
+        // given & when
         Throwable exception = assertThrows(HashtagNotExistException.class, () -> tagRepository.findHashtagByName(tagName));
 
+        // then
         assertThat(exception.getMessage()).isEqualTo("ERROR: Hashtag not exist");
     }
 
-//    @Test
-//    void findHashtagsByPostId() {
-//        Post post = new Post(1, "content", 1);
-//        int postId = postRepository.addPost(post);
-//
-//        String tagName = "맑음";
-//        Hashtag hashtag = new Hashtag(tagName);
-//        int hashtagId = tagRepository.addHashtag(hashtag);
-//
-//        tagRepository.addPostHashtag(postId, hashtagId);
-//
-//        List<String> result = tagRepository.findHashtagsByPostId(postId);
-//        assertThat(result.get(0)).isEqualTo(tagName);
-//    }
+    @Test
+    @DisplayName("게시물 id로 해시태그 조회")
+    void findHashtagsByPostId() {
+        // given
+        int postId = 1;
+
+        // when
+        List<String> result = tagRepository.findHashtagsByPostId(postId);
+
+        // then
+        assertThat(result.size()).isEqualTo(3);
+        assertThat(result.get(0)).isEqualTo("테스트태그1");
+        assertThat(result.get(1)).isEqualTo("테스트태그2");
+        assertThat(result.get(2)).isEqualTo("테스트태그3");
+    }
 
     @ParameterizedTest
     @ValueSource(strings = {"맑", "맑음"})
     @DisplayName("키워드를 접두어로 하여 해시태그를 조회")
     void searchHashtagByPrefix(String keyword) {
+        // given
         String tagName = "맑음";
         Hashtag hashtag = new Hashtag(tagName);
         int hashtagId = tagRepository.addHashtag(hashtag);
 
+        // when
         List<Hashtag> result = tagRepository.searchHashtagByPrefix(keyword);
+
+        // then
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getId()).isEqualTo(hashtagId);
         assertThat(result.get(0).getTag()).isEqualTo(tagName);
@@ -90,11 +98,15 @@ class TagRepositoryTest {
     @ValueSource(strings = {"%", "%%"})
     @DisplayName("'%'문자를 접두어로 하여 해시태그를 조회")
     void searchHashtagByPrefixWithWildCharPercentage(String keyword) {
+        // given
         String tagName = "%%%길동";
         Hashtag hashtag = new Hashtag(tagName);
         int hashtagId = tagRepository.addHashtag(hashtag);
 
+        // when
         List<Hashtag> result = tagRepository.searchHashtagByPrefix(keyword);
+
+        // then
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getId()).isEqualTo(hashtagId);
         assertThat(result.get(0).getTag()).isEqualTo(tagName);
@@ -104,13 +116,30 @@ class TagRepositoryTest {
     @ValueSource(strings = {"_", "__"})
     @DisplayName("'_'를 접두어로 하여 해시태그를 조회")
     void searchHashtagByPrefixWithWildCharUnderBar(String keyword) {
+        // given
         String tagName = "___길동";
         Hashtag hashtag = new Hashtag(tagName);
         int hashtagId = tagRepository.addHashtag(hashtag);
 
+        // when
         List<Hashtag> result = tagRepository.searchHashtagByPrefix(keyword);
+
+        // then
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getId()).isEqualTo(hashtagId);
         assertThat(result.get(0).getTag()).isEqualTo(tagName);
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"1,1,아이오닉 6", "2,1,아이오닉 5", "3,1,넥쏘"})
+    @DisplayName("모델 이름으로 모델 태그 조회")
+    void findModelByName(int modelId, int typeId, String tagName) {
+        // given & when
+        Model result = tagRepository.findModelByName(tagName);
+
+        // then
+        assertThat(result.getId()).isEqualTo(modelId);
+        assertThat(result.getTypeId()).isEqualTo(typeId);
+        assertThat(result.getTag()).isEqualTo(tagName);
     }
 }


### PR DESCRIPTION
## 📌 이슈번호

- #145 

## 📗 요구 사항과 구현 내용
- `tagRepository`에 해시태그 id로 해시태그를 조회하는 `findHashtagById()` 메서드 추가
- `findHashtagsByPostId()`: 게시물 id로 해시태그 조회 테스트 코드 작성
- `findModelByName()`: 모델 이름으로 모델 테그 조회 테스트 코드 작성
- 테스트 코드 리팩토링

## 📖 구현 스크린샷

## 📖 PR 포인트 & 궁금한 점
