### PR TITLE
feat: 무한 스크롤을 위한 PostService 로직 수정

### DIFF
--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Repository;
 import softeer.carbook.domain.post.model.Image;
 
 import javax.sql.DataSource;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -24,22 +23,22 @@ public class ImageRepository {
                 imageRowMapper(), postId);
     }
 
-    public List<Image> getImagesOfRecentPosts(int size, int index) {
+    public List<Image> getImagesOfRecentPosts(int size, int postId) {
         return jdbcTemplate.query("SELECT img.post_id, img.image_url " +
                         "FROM POST AS p INNER JOIN IMAGE AS img ON p.id = img.post_id " +
                         "WHERE p.is_deleted = false and p.id < ? " +
                         "ORDER BY p.create_date DESC LIMIT ?",
-                imageRowMapper(), index, size);
+                imageRowMapper(), postId, size);
     }
 
-    public List<Image> getImagesOfRecentFollowingPosts(int size, int index, int followerId){
+    public List<Image> getImagesOfRecentFollowingPosts(int size, int postId, int followerId){
         return jdbcTemplate.query("SELECT img.post_id, img.image_url " +
                         "FROM POST AS p, IMAGE AS img, FOLLOW AS f " +
                         "where f.is_deleted = false and p.is_deleted = false " +
                         "and p.id < ? and f.follower_id = ? and f.following_id = p.user_id " +
                         "and p.id = img.post_id " +
                         "ORDER BY p.create_date DESC LIMIT ?",
-                imageRowMapper(), index, followerId, size);
+                imageRowMapper(), postId, followerId, size);
     }
 
     public List<Image> findImagesByUserId(int id) {

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -58,17 +58,17 @@ public class PostService {
         this.likeRepository = likeRepository;
     }
 
-    public GuestPostsResponse getRecentPosts(int index) {
-        index = initPostId(index);
-        List<Image> images = imageRepository.getImagesOfRecentPosts(POST_COUNT, index);
+    public GuestPostsResponse getRecentPosts(int postId) {
+        postId = initPostId(postId);
+        List<Image> images = imageRepository.getImagesOfRecentPosts(POST_COUNT, postId);
         return new GuestPostsResponse.GuestPostsResponseBuilder()
                 .images(images)
                 .build();
     }
 
-    public LoginPostsResponse getRecentFollowerPosts(int index, User user) {
-        index = initPostId(index);
-        List<Image> images = imageRepository.getImagesOfRecentFollowingPosts(POST_COUNT, index, user.getId());
+    public LoginPostsResponse getRecentFollowerPosts(int postId, User user) {
+        postId = initPostId(postId);
+        List<Image> images = imageRepository.getImagesOfRecentFollowingPosts(POST_COUNT, postId, user.getId());
         return new LoginPostsResponse.LoginPostsResponseBuilder()
                 .nickname(user.getNickname())
                 .images(images)

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -75,7 +75,11 @@ public class PostService {
                 .build();
     }
 
-    public PostsSearchResponse searchByTags(String hashtags, String type, String model, int index) {
+    public PostsSearchResponse searchByTags(String hashtags, String type, String model, int postId) {
+        if (postId == 0) {
+            postId = Integer.MAX_VALUE;
+        }
+
         List<Post> posts = new ArrayList<>();
         if (type != null) {
             posts.addAll(postRepository.searchByType(type));
@@ -92,7 +96,7 @@ public class PostService {
         }
         logger.debug("size: {}", posts.size());
 
-        List<Image> images = findImagesOfPostsStartsWithIndex(posts, index);
+        List<Image> images = findImagesOfPostsFromPostId(posts, postId);
         return new PostsSearchResponse(images);
     }
 
@@ -130,10 +134,18 @@ public class PostService {
         return !((type != null || model != null) && size == 0);
     }
 
-    private List<Image> findImagesOfPostsStartsWithIndex(List<Post> posts, int index) {
+    private List<Image> findImagesOfPostsFromPostId(List<Post> posts, int postId) {
+        int idx = 0;
+        for (; idx < posts.size(); idx++) {
+            if (posts.get(idx).getId() < postId) {
+                break;
+            }
+        }
+        
         List<Image> images = new ArrayList<>();
-        for (int cnt = index; cnt < index + POST_COUNT && cnt < posts.size(); cnt++) {
-            Image image = imageRepository.getImageByPostId(posts.get(cnt).getId());
+        int curIdx = idx;
+        for (; idx < curIdx + POST_COUNT && idx < posts.size(); idx++) {
+            Image image = imageRepository.getImageByPostId(posts.get(idx).getId());
             images.add(image);
         }
 

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -76,9 +76,7 @@ public class PostService {
     }
 
     public PostsSearchResponse searchByTags(String hashtags, String type, String model, int postId) {
-        if (postId == 0) {
-            postId = Integer.MAX_VALUE;
-        }
+        postId = initPostId(postId);
 
         List<Post> posts = new ArrayList<>();
         if (type != null) {


### PR DESCRIPTION
## 📌 이슈번호

- close #279 

## 📗 요구 사항과 구현 내용 
태그로 게시물 검색 시, 무한 스크롤에서 중복 및 누락 데이터 처리를 위해 기존의 index에서 postId를 활용하도록 PostService의 로직을 수정하였습니다.
- `findImagesOfPostsFromPostId()` 로직 변경
    - offset 대신 이전 응답으로 보낸 게시글 중 마지막 게시글의 id를 요청 파라미터로 받기 때문에, 현재 조회한 게시글에서 postId보다 작은 아이디를 가진 Post를 찾은 후, 그 post부터 POST_COUNT 만큼의 개수의 이미지를 응답으로 반환하도록 변경하였습니다.

## 📖 구현 스크린샷

## 📖 PR 포인트 & 궁금한 점
