### PR TITLE
feat: 좋아요 개수 반정규화 진행 구현

### DIFF
--- a/backend/carbook/src/main/java/softeer/carbook/domain/like/controller/LikeController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/like/controller/LikeController.java
@@ -1,5 +1,7 @@
 package softeer.carbook.domain.like.controller;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -7,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import softeer.carbook.domain.like.dto.ModifyLikeInfoForm;
 import softeer.carbook.domain.like.service.LikeService;
+import softeer.carbook.domain.post.controller.PostController;
 import softeer.carbook.domain.user.model.User;
 import softeer.carbook.domain.user.service.UserService;
 import softeer.carbook.global.dto.Message;
@@ -17,6 +20,7 @@ import javax.servlet.http.HttpServletRequest;
 public class LikeController {
     private final LikeService likeService;
     private final UserService userService;
+    private static final Logger logger = LoggerFactory.getLogger(LikeController.class);
 
     @Autowired
     public LikeController(
@@ -34,6 +38,8 @@ public class LikeController {
             @RequestBody ModifyLikeInfoForm modifyLikeInfoForm,
             HttpServletRequest httpServletRequest
     ){
+        long startTime = System.currentTimeMillis();
+
         // 일단 로그인 확인 후 로그인한 유저 받아오기
         User loginUser = userService.findLoginedUser(httpServletRequest);
 
@@ -42,6 +48,9 @@ public class LikeController {
                 loginUser.getId(),
                 modifyLikeInfoForm.getPostId()
         );
+        long endTime = System.currentTimeMillis();
+        logger.info("Time in milliSeconds: {}", endTime - startTime);
+
         return Message.make200Response(resultMsg.getMessage());
 
     }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/like/repository/LikeRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/like/repository/LikeRepository.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import softeer.carbook.domain.user.model.User;
 
 import javax.sql.DataSource;
@@ -37,16 +38,22 @@ public class LikeRepository {
                 idRowMapper(), userId, postId).stream().findAny();
     }
 
-    public void unLike(int likeId) {
+    @Transactional
+    public void unLike(int likeId, int postId) {
         jdbcTemplate.update(
                 "update POST_LIKE set is_deleted = true where id = ?", likeId);
+        jdbcTemplate.update(
+                "update POST set like_count = like_count - 1 where id = ?", postId);
     }
 
+    @Transactional
     public void addLike(int userId, int postId) {
         jdbcTemplate.update(
         "insert into POST_LIKE(user_id, post_id) values (?, ?) " +
                 "on DUPLICATE KEY update is_deleted = false",
                 userId, postId);
+        jdbcTemplate.update(
+                "update POST set like_count = like_count + 1 where id = ?", postId);
     }
 
     private RowMapper<Integer> idRowMapper(){

--- a/backend/carbook/src/main/java/softeer/carbook/domain/like/service/LikeService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/like/service/LikeService.java
@@ -19,11 +19,12 @@ public class LikeService {
     }
 
     public Message modifyLikeInfo(int userId, int postId) {
+
         Optional<Integer> likeId = likeRepository.findLikeByUserIdAndPostId(userId, postId);
         // 좋아요 여부 판단
         if(likeId.isPresent()){
             // 좋아요 취소 진행
-            likeRepository.unLike(likeId.get());
+            likeRepository.unLike(likeId.get(), postId);
             return new Message("UnLike Success");
         }
 

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/model/Post.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/model/Post.java
@@ -10,6 +10,7 @@ public class Post {
     private Timestamp updateDate;
     private String content;
     private int modelId;
+    private int likeCount;
 
     public Post(int userId, String content, int modelId) {
         this.userId = userId;
@@ -24,19 +25,27 @@ public class Post {
         this.modelId = modelId;
     }
 
-    public Post(int id, int userId, Timestamp createDate, Timestamp updateDate, String content, int modelId) {
+    public Post(
+            int id, int userId,
+            Timestamp createDate, Timestamp updateDate,
+            String content, int modelId,
+            int likeCount) {
         this.id = id;
         this.userId = userId;
         this.createDate = createDate;
         this.updateDate = updateDate;
         this.content = content;
         this.modelId = modelId;
+        this.likeCount = likeCount;
     }
 
     public int getId() {
         return id;
     }
 
+    public int getLikeCount() {
+        return likeCount;
+    }
 
     public int getUserId() {
         return userId;

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/PostRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/PostRepository.java
@@ -45,7 +45,7 @@ public class PostRepository {
      */
     public Post findPostById(int postId) {
         List<Post> post = jdbcTemplate.query(
-                "SELECT id, user_id, create_date, update_date, content, model_id " +
+                "SELECT id, user_id, create_date, update_date, content, model_id, like_count " +
                         "FROM POST " +
                         "WHERE id = ? AND is_deleted = false", postRowMapper(), postId);
         return post.stream().findAny().orElseThrow(
@@ -54,18 +54,18 @@ public class PostRepository {
     }
 
     public List<Post> searchByType(String type) {
-        return jdbcTemplate.query("SELECT p.id, p.user_id, p.create_date, p.update_date, p.content, p.model_id FROM TYPE t " +
+        return jdbcTemplate.query("SELECT p.id, p.user_id, p.create_date, p.update_date, p.content, p.model_id, p.like_count FROM TYPE t " +
                 "INNER JOIN MODEL m ON (t.id = m.type_id AND t.tag = ?) " +
                 "INNER JOIN POST p ON m.id = p.model_id  WHERE p.is_deleted = false ORDER BY p.create_date DESC", postRowMapper(), type);
     }
 
     public List<Post> searchByModel(String model) {
-        return jdbcTemplate.query("SELECT p.id, p.user_id, p.create_date, p.update_date, p.content, p.model_id FROM MODEL m " +
+        return jdbcTemplate.query("SELECT p.id, p.user_id, p.create_date, p.update_date, p.content, p.model_id, p.like_count FROM MODEL m " +
                 "INNER JOIN POST p ON (m.id = p.model_id AND m.tag = ?) WHERE p.is_deleted = false ORDER BY p.create_date DESC", postRowMapper(), model);
     }
 
     public List<Post> searchByHashtag(String tagName) {
-        return jdbcTemplate.query("SELECT p.id, p.user_id, p.create_date, p.update_date, p.content, p.model_id FROM POST p " +
+        return jdbcTemplate.query("SELECT p.id, p.user_id, p.create_date, p.update_date, p.content, p.model_id, p.like_count FROM POST p " +
                 "INNER JOIN POST_HASHTAG ph ON p.id = ph.post_id " +
                 "INNER JOIN HASHTAG h ON ph.tag_id = h.id AND h.tag = ? WHERE p.is_deleted = false ORDER BY p.create_date DESC", postRowMapper(), tagName);
     }
@@ -99,7 +99,8 @@ public class PostRepository {
                 rs.getTimestamp("create_date"),
                 rs.getTimestamp("update_date"),
                 rs.getString("content"),
-                rs.getInt("model_id")
+                rs.getInt("model_id"),
+                rs.getInt("like_count")
         );
     }
 }

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -202,7 +202,7 @@ public class PostService {
                 .nickname(userRepository.findUserById(post.getUserId()).getNickname())
                 .imageUrl(imageRepository.getImageByPostId(postId).getImageUrl())
                 .isLike(likeRepository.checkLike(user.getId(), postId))
-                .likeCount(likeRepository.findLikeCountByPostId(postId))
+                .likeCount(post.getLikeCount())
                 .createDate(dateToString(post.getCreateDate()))
                 .updateDate(dateToString(post.getUpdateDate()))
                 .hashtags(hashtags)

--- a/backend/carbook/src/main/java/softeer/carbook/global/interceptor/LoginInterceptor.java
+++ b/backend/carbook/src/main/java/softeer/carbook/global/interceptor/LoginInterceptor.java
@@ -18,9 +18,9 @@ public class LoginInterceptor implements HandlerInterceptor {
     private static final Logger logger = LoggerFactory.getLogger(LoginInterceptor.class);
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        logger.info("인터셉터 진입");
+        logger.debug("인터셉터 진입");
         checkLoginException(request.getSession(false));
-        logger.info("예외 없음");
+        logger.debug("예외 없음");
         return true;
         //return HandlerInterceptor.super.preHandle(request, response, handler);
     }

--- a/backend/carbook/src/test/java/softeer/carbook/domain/like/repository/LikeRepositoryTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/like/repository/LikeRepositoryTest.java
@@ -66,7 +66,7 @@ class LikeRepositoryTest {
     @DisplayName("좋아요 취소 테스트")
     void unLike() {
         // when
-        likeRepository.unLike(1);
+        likeRepository.unLike(1, 1);
         boolean isUnLike = likeRepository.findLikeByUserIdAndPostId(1, 1).isEmpty();
 
         // then

--- a/backend/carbook/src/test/java/softeer/carbook/domain/like/service/LikeServiceTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/like/service/LikeServiceTest.java
@@ -54,7 +54,7 @@ class LikeServiceTest {
         // then
         assertThat(result.getMessage()).isEqualTo("UnLike Success");
         verify(likeRepository).findLikeByUserIdAndPostId(anyInt(), anyInt());
-        verify(likeRepository).unLike(anyInt());
+        verify(likeRepository).unLike(anyInt(), anyInt());
     }
 
 }

--- a/backend/carbook/src/test/java/softeer/carbook/domain/post/service/PostServiceTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/post/service/PostServiceTest.java
@@ -76,8 +76,8 @@ class PostServiceTest {
     ));
 
     private final List<Post> posts = new ArrayList<>(List.of(
-            new Post(8, 8, null, null, null, 8),
-            new Post(6, 6, null, null, null, 6)
+            new Post(8, 8, null, null, null, 8, 24),
+            new Post(6, 6, null, null, null, 6, 25)
     ));
     private final Image image1 = new Image(8, "/eighth/image.jpg");
     private final Image image2 = new Image(6, "/sixth/image.jpg");
@@ -372,7 +372,7 @@ class PostServiceTest {
     void getMyPostDetails() {
         // given
         User user = new User(17, "user17@email.com", "사용자17", "pw17");
-        Post post = new Post(1, 17, new Timestamp(12341241), new Timestamp(1231235), "asdf", 1);
+        Post post = new Post(1, 17, new Timestamp(12341241), new Timestamp(1231235), "asdf", 1, 23);
         Image image = images.get(0);
         List<Type> types = new ArrayList<>(List.of(
                 new Type(1, "승용"), new Type(2, "SUV")));
@@ -387,7 +387,6 @@ class PostServiceTest {
         given(tagRepository.findTypeById(anyInt())).willReturn(types);
         given(imageRepository.getImageByPostId(anyInt())).willReturn(image);
         given(likeRepository.checkLike(anyInt(), anyInt())).willReturn(true);
-        given(likeRepository.findLikeCountByPostId(anyInt())).willReturn(123);
         given(userRepository.findUserById(anyInt())).willReturn(user);
 
         // when
@@ -401,7 +400,6 @@ class PostServiceTest {
         verify(tagRepository).findTypeById(anyInt());
         verify(imageRepository).getImageByPostId(anyInt());
         verify(likeRepository).checkLike(anyInt(),anyInt());
-        verify(likeRepository).findLikeCountByPostId(anyInt());
         verify(userRepository).findUserById(anyInt());
     }
 
@@ -410,7 +408,7 @@ class PostServiceTest {
     void getOtherPostDetails() {
         // given
         User user = new User(17, "user17@email.com", "사용자17", "pw17");
-        Post post = new Post(1, 1, new Timestamp(12341241), new Timestamp(1231235), "asdf", 1);
+        Post post = new Post(1, 1, new Timestamp(12341241), new Timestamp(1231235), "asdf", 1, 23);
         Image image = images.get(0);
         List<Type> types = new ArrayList<>(List.of(
                 new Type(1, "승용"), new Type(2, "SUV")));
@@ -425,7 +423,6 @@ class PostServiceTest {
         given(tagRepository.findTypeById(anyInt())).willReturn(types);
         given(imageRepository.getImageByPostId(anyInt())).willReturn(image);
         given(likeRepository.checkLike(anyInt(), anyInt())).willReturn(true);
-        given(likeRepository.findLikeCountByPostId(anyInt())).willReturn(123);
         given(userRepository.findUserById(anyInt())).willReturn(user);
 
         // when
@@ -439,7 +436,6 @@ class PostServiceTest {
         verify(tagRepository).findTypeById(anyInt());
         verify(imageRepository).getImageByPostId(anyInt());
         verify(likeRepository).checkLike(anyInt(),anyInt());
-        verify(likeRepository).findLikeCountByPostId(anyInt());
         verify(userRepository).findUserById(anyInt());
     }
 
@@ -448,7 +444,7 @@ class PostServiceTest {
     void deletePost() {
         // given
         User user = new User(17, "user17@email.com", "사용자17", "pw17");
-        Post post = new Post(1, 17, new Timestamp(12341241), new Timestamp(1231235), "asdf", 1);
+        Post post = new Post(1, 17, new Timestamp(12341241), new Timestamp(1231235), "asdf", 1, 23);
         given(postRepository.findPostById(anyInt())).willReturn(post);
 
         // when
@@ -464,7 +460,7 @@ class PostServiceTest {
     void deleteOtherUserPost() {
         // given
         User user = new User(17, "user17@email.com", "사용자17", "pw17");
-        Post post = new Post(1, 1, new Timestamp(12341241), new Timestamp(1231235), "asdf", 1);
+        Post post = new Post(1, 1, new Timestamp(12341241), new Timestamp(1231235), "asdf", 1, 23);
         given(postRepository.findPostById(anyInt())).willReturn(post);
 
         // when
@@ -579,7 +575,7 @@ class PostServiceTest {
         ModifiedPostForm modifiedPostForm = new ModifiedPostForm(100, image, hashtagNames, "승용", "쏘나타", "테스트 쏘나타 게시글입니다");
 
         User user = new User(17, "user17@email.com", "사용자17", "pw17");
-        Post post = new Post(1, 1, new Timestamp(12341241), new Timestamp(1231235), "asdf", 1);
+        Post post = new Post(1, 1, new Timestamp(12341241), new Timestamp(1231235), "asdf", 1, 23);
         given(postRepository.findPostById(anyInt())).willReturn(post);
         // when
         Throwable exception = assertThrows(InvalidPostAccessException.class, () -> {

--- a/backend/carbook/src/test/resources/create_table.sql
+++ b/backend/carbook/src/test/resources/create_table.sql
@@ -81,6 +81,7 @@ create table POST
     content     varchar(500)                         null,
     model_id    int                                  not null,
     is_deleted  boolean default 0                 not null,
+    like_count  int        default 0                 not null,
     constraint post_model_id_fk
         foreign key (model_id) references MODEL (id)
             on update cascade on delete cascade,


### PR DESCRIPTION
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
좋아요 테이블에서 count 함수를 통해 가져오던 좋아요 개수를 
게시글 테이블에 칼럼으로 추가해서 반정규화 진행하였습니다. 성능이 개선되었습니다.
테스트 코드 수정 하였고 포스트맨을 통해 테스트 완료 하였습니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
<img width="406" alt="스크린샷 2023-02-22 오후 12 20 12" src="https://user-images.githubusercontent.com/46276276/220512888-7138c1ee-43bd-4cf0-9424-926492e7eb2c.png">


## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
