### PR TITLE
feat: 최근 일주일간의 인기글 조회

### DIFF
--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/controller/PostController.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/controller/PostController.java
@@ -39,10 +39,15 @@ public class PostController {
         return new ResponseEntity<>(postService.getRecentPosts(index), HttpStatus.OK);
     }
 
-
     private ResponseEntity<LoginPostsResponse> getLoginPosts(int index, HttpServletRequest httpServletRequest){
         return new ResponseEntity<>(postService.getRecentFollowerPosts(index, userService.findLoginedUser(httpServletRequest)), HttpStatus.OK);
     }
+
+    @GetMapping("/posts/m/popular")
+    public ResponseEntity<LoginPostsResponse> getPopularPosts(@RequestParam int index, HttpServletRequest httpServletRequest) {
+        return new ResponseEntity<>(postService.getPopularPostsDuringWeek(index, userService.findLoginedUser(httpServletRequest)), HttpStatus.OK);
+    }
+
 
         // todo 로그인한 사람의 게시물 조회 ( 팔로우 )
             // mainpage url  + cookie

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
@@ -42,6 +42,13 @@ public class ImageRepository {
                 imageRowMapper(),  postId, followerId, size);
     }
 
+    public List<Image> getImagesOfPopularPostsDuringWeek(int size, int postId, String lastWeekDay) {
+        return jdbcTemplate.query("SELECT img.post_id, img.image_url " +
+                "FROM POST p INNER JOIN IMAGE img " +
+                "ON p.id = img.post_id AND p.is_deleted = false AND p.id < ? AND p.create_date > '" + lastWeekDay + "' " +
+                "ORDER BY p.like_count DESC, p.create_date DESC LIMIT ?", imageRowMapper(), postId, size);
+    }
+
     public List<Image> findImagesByUserId(int id) {
         return jdbcTemplate.query(
                 "select IMAGE.post_id, IMAGE.image_url from POST INNER JOIN IMAGE " +

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -79,6 +79,19 @@ public class PostService {
                 .build();
     }
 
+    public LoginPostsResponse getPopularPostsDuringWeek(int postId, User user) {
+        postId = initPostId(postId);
+
+        LocalDateTime lastWeek = LocalDateTime.now().minusWeeks(1);
+        String lastWeekDay = lastWeek.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+        List<Image> images = imageRepository.getImagesOfPopularPostsDuringWeek(POST_COUNT, postId, lastWeekDay);
+        return new LoginPostsResponse.LoginPostsResponseBuilder()
+                .nickname(user.getNickname())
+                .images(images)
+                .build();
+    }
+
     public PostsSearchResponse searchByTags(String hashtags, String type, String model, int postId) {
         postId = initPostId(postId);
 

--- a/backend/carbook/src/test/java/softeer/carbook/domain/post/controller/PostControllerTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/post/controller/PostControllerTest.java
@@ -100,6 +100,22 @@ class PostControllerTest {
     }
 
     @Test
+    @DisplayName("인기글 조회 테스트")
+    void getPopularPosts() throws Exception {
+        // given
+        LoginPostsResponse loginPostsResponse = new LoginPostsResponse.LoginPostsResponseBuilder()
+                .nickname("nickname")
+                .images(images)
+                .build();
+        given(postService.getPopularPostsDuringWeek(anyInt(), any())).willReturn(loginPostsResponse);
+
+        // when & then
+        mockMvc.perform(get("/posts/m/popular?index=0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.login").value(true));
+    }
+
+    @Test
     @DisplayName("태그로 글 검색 테스트")
     void searchPostsByTags() throws Exception {
         // given

--- a/backend/carbook/src/test/java/softeer/carbook/domain/post/repository/ImageRepositoryTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/post/repository/ImageRepositoryTest.java
@@ -3,32 +3,19 @@ package softeer.carbook.domain.post.repository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.junit4.SpringRunner;
-import softeer.carbook.domain.follow.repository.FollowRepository;
 import softeer.carbook.domain.post.model.Image;
 import softeer.carbook.domain.post.model.Post;
-import softeer.carbook.domain.user.model.User;
-import softeer.carbook.domain.user.repository.UserRepository;
 
 import javax.sql.DataSource;
-import javax.xml.crypto.Data;
-
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @JdbcTest
 @Sql("classpath:create_table.sql")
@@ -77,6 +64,22 @@ class ImageRepositoryTest {
         LocalDateTime lastWeek = LocalDateTime.now().minusWeeks(1);
         String lastWeekDay = lastWeek.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         List<Image> resultImages = imageRepository.getImagesOfRecentFollowingPosts(size, index, followerId, lastWeekDay);
+        assertThat(resultImages).usingRecursiveComparison().isEqualTo(expectedImages);
+    }
+
+    @Test
+    @DisplayName("인기글 조회 테스트")
+    void getImagesOfPopularPostsDuringWeek() {
+        int size = 2;
+        int index = 9;
+        List<Image> expectedImages = new ArrayList<>();
+        expectedImages.add(new Image(1,"https://team2-carbook.s3.ap-northeast-2.amazonaws.com/images/1_이미지.jpeg"));
+        expectedImages.add(new Image(4,"https://team2-carbook.s3.ap-northeast-2.amazonaws.com/images/4_이미지.jpeg"));
+        LocalDateTime lastWeek = LocalDateTime.now().minusWeeks(1);
+        String lastWeekDay = lastWeek.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+        List<Image> resultImages = imageRepository.getImagesOfPopularPostsDuringWeek(size, index, lastWeekDay);
+
         assertThat(resultImages).usingRecursiveComparison().isEqualTo(expectedImages);
     }
 

--- a/backend/carbook/src/test/java/softeer/carbook/domain/post/service/PostServiceTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/post/service/PostServiceTest.java
@@ -163,6 +163,25 @@ class PostServiceTest {
     }
 
     @Test
+    @DisplayName("인기글 조회 테스트")
+    void getPopularPostsDuringWeek() {
+        //given
+        int postId = 9;
+        String lastWeekDay = "2023-02-15";
+        User user = new User(15, "user15@exam.com", "15번유저", "pw15");
+        given(imageRepository.getImagesOfPopularPostsDuringWeek(POST_COUNT, postId, lastWeekDay)).willReturn(images);
+
+        //when
+        LoginPostsResponse loginPostsResponse = postService.getPopularPostsDuringWeek(postId, user);
+
+        //then
+        assertThat(loginPostsResponse.isLogin()).isTrue();
+        ///assertThat(loginPostsResponse.getImages()).isEqualTo(images);
+
+        //verify(imageRepository).getImagesOfPopularPostsDuringWeek(POST_COUNT, postId, lastWeekDay);
+    }
+
+    @Test
     @DisplayName("해시태그, 타입, 모델 태그로 게시물을 검색한 경우 테스트")
     void searchByTagsWithHashtagsAndTypeAndModel() {
         // given

--- a/backend/carbook/src/test/java/softeer/carbook/domain/post/service/PostServiceTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/post/service/PostServiceTest.java
@@ -7,10 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import softeer.carbook.domain.follow.repository.FollowRepository;
 import softeer.carbook.domain.like.repository.LikeRepository;
@@ -30,10 +27,9 @@ import softeer.carbook.domain.user.model.User;
 import softeer.carbook.domain.user.repository.UserRepository;
 import softeer.carbook.global.dto.Message;
 
-import java.sql.Timestamp;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -41,7 +37,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -167,8 +162,9 @@ class PostServiceTest {
     void getPopularPostsDuringWeek() {
         //given
         int postId = 9;
-        String lastWeekDay = "2023-02-15";
         User user = new User(15, "user15@exam.com", "15번유저", "pw15");
+        LocalDateTime lastWeek = LocalDateTime.now().minusWeeks(1);
+        String lastWeekDay = lastWeek.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         given(imageRepository.getImagesOfPopularPostsDuringWeek(POST_COUNT, postId, lastWeekDay)).willReturn(images);
 
         //when
@@ -176,9 +172,9 @@ class PostServiceTest {
 
         //then
         assertThat(loginPostsResponse.isLogin()).isTrue();
-        ///assertThat(loginPostsResponse.getImages()).isEqualTo(images);
+        assertThat(loginPostsResponse.getImages()).isEqualTo(images);
 
-        //verify(imageRepository).getImagesOfPopularPostsDuringWeek(POST_COUNT, postId, lastWeekDay);
+        verify(imageRepository).getImagesOfPopularPostsDuringWeek(POST_COUNT, postId, lastWeekDay);
     }
 
     @Test

--- a/backend/carbook/src/test/resources/create_data.sql
+++ b/backend/carbook/src/test/resources/create_data.sql
@@ -81,15 +81,15 @@ values (1,2,0),
        (2,4,0),
        (4,3,0);
 
-insert into POST (user_id, create_date, update_date, content, model_id, is_deleted)
-values (1,TIMESTAMPADD(DAY, -5, NOW()),'2023-02-07 11:24:24','1번 유저 첫글',1,0),
-       (1,TIMESTAMPADD(DAY, -6, NOW()),'2023-02-07 11:25:10','1번 유저 두번째글',2,0),
-       (2,TIMESTAMPADD(DAY, -4, NOW()),'2023-02-07 11:25:20','2번 유저 첫글',3,1),
-       (2,TIMESTAMPADD(DAY, -3, NOW()),'2023-02-07 11:25:33','2번 유저 두번째글',4,0),
-       (3,TIMESTAMPADD(DAY, -2, NOW()),'2023-02-07 11:25:35','3번 유저 첫글',5,0),
-       (3,TIMESTAMPADD(DAY, -1, NOW()),'2023-02-07 11:25:45','3번 유저 두번째글',6,1),
-       (4,NOW(),'2023-02-07 11:27:33','4번 유저 첫글',7,0),
-       (4,TIMESTAMPADD(DAY, 1, NOW()),'2023-02-07 11:28:33','4번 유저 두번째글',8,0);
+insert into POST (user_id, create_date, update_date, content, model_id, is_deleted, like_count)
+values (1,TIMESTAMPADD(DAY, -5, NOW()),'2023-02-07 11:24:24','1번 유저 첫글',1,0,3),
+       (1,TIMESTAMPADD(DAY, -6, NOW()),'2023-02-07 11:25:10','1번 유저 두번째글',2,0,0),
+       (2,TIMESTAMPADD(DAY, -4, NOW()),'2023-02-07 11:25:20','2번 유저 첫글',3,1,3),
+       (2,TIMESTAMPADD(DAY, -3, NOW()),'2023-02-07 11:25:33','2번 유저 두번째글',4,0,2),
+       (3,TIMESTAMPADD(DAY, -2, NOW()),'2023-02-07 11:25:35','3번 유저 첫글',5,0,0),
+       (3,TIMESTAMPADD(DAY, -1, NOW()),'2023-02-07 11:25:45','3번 유저 두번째글',6,1,0),
+       (4,NOW(),'2023-02-07 11:27:33','4번 유저 첫글',7,0,0),
+       (4,TIMESTAMPADD(DAY, 1, NOW()),'2023-02-07 11:28:33','4번 유저 두번째글',8,0,0);
 
 insert into IMAGE (post_id, image_url)
 values (1, 'https://team2-carbook.s3.ap-northeast-2.amazonaws.com/images/1_이미지.jpeg'),


### PR DESCRIPTION
## 📌 이슈번호

- close #326 

## 📗 요구 사항과 구현 내용
기존에는 로그인한 사용자의 경우 메인페이지에서 팔로우한 사람의 게시글만 보이도록 하였는데, 팔로우한 사람이 없는 신규 사용자의 경우 아무 게시글도 보이지 않습니다. 이를 개선하기 위해 로그인한 사용자의 경우 메인페이지에서 팔로우한 사람의 게시글을 다 본 후에는 인기글이 보이도록 결정하였습니다.
인기글은 일주일 내에 작성한 게시글 중 좋아요가 많은 순서대로 보여줍니다.
테스트 코드도 작성했습니다.

## 📖 구현 스크린샷

## 📖 PR 포인트 & 궁금한 점
