### PR TITLE
fix: 인기글 조회 로직 수정

### DIFF
--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/ImageRepository.java
@@ -42,13 +42,6 @@ public class ImageRepository {
                 imageRowMapper(),  postId, followerId, size);
     }
 
-    public List<Image> getImagesOfPopularPostsDuringWeek(int size, int postId, String lastWeekDay) {
-        return jdbcTemplate.query("SELECT img.post_id, img.image_url " +
-                "FROM POST p INNER JOIN IMAGE img " +
-                "ON p.id = img.post_id AND p.is_deleted = false AND p.id < ? AND p.create_date > '" + lastWeekDay + "' " +
-                "ORDER BY p.like_count DESC, p.create_date DESC LIMIT ?", imageRowMapper(), postId, size);
-    }
-
     public List<Image> findImagesByUserId(int id) {
         return jdbcTemplate.query(
                 "select IMAGE.post_id, IMAGE.image_url from POST INNER JOIN IMAGE " +

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/PostRepository.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/repository/PostRepository.java
@@ -10,7 +10,6 @@ import softeer.carbook.domain.post.exception.PostNotExistException;
 import softeer.carbook.domain.post.model.Post;
 
 import javax.sql.DataSource;
-import java.math.BigInteger;
 import java.sql.PreparedStatement;
 import java.sql.Statement;
 import java.util.List;
@@ -51,6 +50,12 @@ public class PostRepository {
         return post.stream().findAny().orElseThrow(
                 PostNotExistException::new
         );
+    }
+
+    public List<Post> findPopularPostsDuringWeek(String lastWeekDay) {
+        return jdbcTemplate.query("SELECT p.id, p.user_id, p.create_date, p.update_date, p.content, p.model_id, p.like_count FROM POST p " +
+                "WHERE p.is_deleted = false AND p.create_date > '" + lastWeekDay + "' " +
+                "ORDER BY p.like_count DESC, p.create_date DESC", postRowMapper());
     }
 
     public List<Post> searchByType(String type) {

--- a/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
+++ b/backend/carbook/src/main/java/softeer/carbook/domain/post/service/PostService.java
@@ -80,16 +80,40 @@ public class PostService {
     }
 
     public LoginPostsResponse getPopularPostsDuringWeek(int postId, User user) {
-        postId = initPostId(postId);
-
         LocalDateTime lastWeek = LocalDateTime.now().minusWeeks(1);
         String lastWeekDay = lastWeek.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
 
-        List<Image> images = imageRepository.getImagesOfPopularPostsDuringWeek(POST_COUNT, postId, lastWeekDay);
+        List<Post> popularPosts = postRepository.findPopularPostsDuringWeek(lastWeekDay);
+
+        List<Image> images = findImagesOfPopularPostsFromPostId(popularPosts, postId);
         return new LoginPostsResponse.LoginPostsResponseBuilder()
                 .nickname(user.getNickname())
                 .images(images)
                 .build();
+    }
+
+    private List<Image> findImagesOfPopularPostsFromPostId(List<Post> posts, int postId) {
+        int idx, curIdx;
+
+        if (postId == 0) {
+            idx = curIdx = 0;
+        }
+        else {
+            for (idx = 0; idx < posts.size(); idx++) {
+                if (posts.get(idx).getId() == postId) {
+                    break;
+                }
+            }
+            curIdx = ++idx;
+        }
+
+        List<Image> images = new ArrayList<>();
+        for (; idx < curIdx + POST_COUNT && idx < posts.size(); idx++) {
+            Image image = imageRepository.getImageByPostId(posts.get(idx).getId());
+            images.add(image);
+        }
+
+        return images;
     }
 
     public PostsSearchResponse searchByTags(String hashtags, String type, String model, int postId) {

--- a/backend/carbook/src/test/java/softeer/carbook/domain/post/repository/ImageRepositoryTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/post/repository/ImageRepositoryTest.java
@@ -68,22 +68,6 @@ class ImageRepositoryTest {
     }
 
     @Test
-    @DisplayName("인기글 조회 테스트")
-    void getImagesOfPopularPostsDuringWeek() {
-        int size = 2;
-        int index = 9;
-        List<Image> expectedImages = new ArrayList<>();
-        expectedImages.add(new Image(1,"https://team2-carbook.s3.ap-northeast-2.amazonaws.com/images/1_이미지.jpeg"));
-        expectedImages.add(new Image(4,"https://team2-carbook.s3.ap-northeast-2.amazonaws.com/images/4_이미지.jpeg"));
-        LocalDateTime lastWeek = LocalDateTime.now().minusWeeks(1);
-        String lastWeekDay = lastWeek.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-
-        List<Image> resultImages = imageRepository.getImagesOfPopularPostsDuringWeek(size, index, lastWeekDay);
-
-        assertThat(resultImages).usingRecursiveComparison().isEqualTo(expectedImages);
-    }
-
-    @Test
     @DisplayName("User Id로 이미지 조회 테스트")
     void findImagesByUserId() {
         int userId = 1;

--- a/backend/carbook/src/test/java/softeer/carbook/domain/post/repository/PostRepositoryTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/post/repository/PostRepositoryTest.java
@@ -11,6 +11,8 @@ import softeer.carbook.domain.post.model.Post;
 
 import javax.sql.DataSource;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,6 +51,17 @@ class PostRepositoryTest {
         assertThat(result.getUserId()).isEqualTo(userId);
         assertThat(result.getContent()).isEqualTo(content);
         assertThat(result.getModelId()).isEqualTo(modelId);
+    }
+
+    @Test
+    @DisplayName("인기글 조회 테스트")
+    void getImagesOfPopularPostsDuringWeek() {
+        LocalDateTime lastWeek = LocalDateTime.now().minusWeeks(1);
+        String lastWeekDay = lastWeek.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+        List<Post> result = postRepository.findPopularPostsDuringWeek(lastWeekDay);
+
+        assertThat(result.size()).isEqualTo(6);
     }
 
     @Test

--- a/backend/carbook/src/test/java/softeer/carbook/domain/post/service/PostServiceTest.java
+++ b/backend/carbook/src/test/java/softeer/carbook/domain/post/service/PostServiceTest.java
@@ -161,20 +161,24 @@ class PostServiceTest {
     @DisplayName("인기글 조회 테스트")
     void getPopularPostsDuringWeek() {
         //given
-        int postId = 9;
+        int postId = 0;
         User user = new User(15, "user15@exam.com", "15번유저", "pw15");
         LocalDateTime lastWeek = LocalDateTime.now().minusWeeks(1);
         String lastWeekDay = lastWeek.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-        given(imageRepository.getImagesOfPopularPostsDuringWeek(POST_COUNT, postId, lastWeekDay)).willReturn(images);
+        given(postRepository.findPopularPostsDuringWeek(lastWeekDay)).willReturn(posts);
+        given(imageRepository.getImageByPostId(8)).willReturn(image1);
+        given(imageRepository.getImageByPostId(6)).willReturn(image2);
 
         //when
         LoginPostsResponse loginPostsResponse = postService.getPopularPostsDuringWeek(postId, user);
 
         //then
         assertThat(loginPostsResponse.isLogin()).isTrue();
-        assertThat(loginPostsResponse.getImages()).isEqualTo(images);
+        assertThat(loginPostsResponse.getImages()).usingRecursiveComparison().isEqualTo(imagesEightAndSix);
 
-        verify(imageRepository).getImagesOfPopularPostsDuringWeek(POST_COUNT, postId, lastWeekDay);
+        verify(postRepository).findPopularPostsDuringWeek(lastWeekDay);
+        verify(imageRepository).getImageByPostId(8);
+        verify(imageRepository).getImageByPostId(6);
     }
 
     @Test


### PR DESCRIPTION
## 📌 이슈번호

- #326 

## 📗 요구 사항과 구현 내용
기존의 인기글 조회 로직은 메인 페이지의 게시물 조회 로직과 같은 방식으로 구현했지만, 인기글 조회는 좋아요 개수가 많은 순서대로 정렬되므로 postId를 기준 삼아서 게시글을 조회하는 방식은 오류를 발생했습니다.
따라서 최근 일주일간 생성된 게시물 중 좋아요 개수가 많은 순서대로 정렬된 게시물 리스트를 받은 다음, 프론트가 넘겨준 postId를 리스트에서 찾아서, 그 다음 게시물의 이미지를 반환하는 방식으로 변경하였습니다.
변경사항에 따라 테스트코드도 추가하고 수정했습니다.

## 📖 구현 스크린샷

## 📖 PR 포인트 & 궁금한 점
